### PR TITLE
Xcvrd Refactor 3/N: Breakup task_worker into separate functions

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3,7 +3,7 @@ from xcvrd.xcvrd_utilities.port_event_helper import *
 from xcvrd.xcvrd_utilities.sfp_status_helper import *
 from xcvrd.xcvrd_utilities.media_settings_parser import *
 from xcvrd.xcvrd_utilities.optics_si_parser import *
-from xcvrd.xcvrd_utilities import common
+from xcvrd.xcvrd_utilities import xcvrd_common
 from xcvrd.dom.dom_mgr import *
 from xcvrd.xcvrd import *
 from xcvrd.cmis import CmisManagerTask
@@ -293,11 +293,11 @@ class TestXcvrdThreadException(object):
         assert("sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py" in str(trace))
         assert("update_port_transceiver_status_table_sw_cmis_state" in str(trace))
 
-    @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
-    @patch('xcvrd.cmis.CmisManagerTask.wait_for_port_config_done', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=False))
-    @patch('xcvrd.xcvrd_utilities.common.get_cmis_application_desired', MagicMock(side_effect=KeyError))
-    @patch('xcvrd.xcvrd_utilities.common.log_exception_traceback')
+    @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
+    @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_fast_reboot_enabled', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.get_cmis_application_desired', MagicMock(side_effect=KeyError))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.log_exception_traceback')
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_state_port_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
@@ -323,7 +323,7 @@ class TestXcvrdThreadException(object):
         mock_sfp.get_xcvr_api = MagicMock(side_effect=NotImplementedError)
         task.task_worker()
         assert mock_log_exception_traceback.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
 
         # Case 2: is_flat_memory() raises AttributeError. In this case, CMIS SM should transition to READY state
         mock_xcvr_api = MagicMock()
@@ -332,7 +332,7 @@ class TestXcvrdThreadException(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.on_port_update_event(port_change_event)
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
 
         # Case 2.5: get_module_type_abbreviation() returns unsupported module type. In this case, CMIS SM should transition to READY state
         mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
@@ -340,7 +340,7 @@ class TestXcvrdThreadException(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.on_port_update_event(port_change_event)
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
 
         # Case 3: get_cmis_application_desired() raises an exception
         mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
@@ -351,7 +351,7 @@ class TestXcvrdThreadException(object):
         task.get_cmis_host_lanes_mask = MagicMock()
         task.task_worker()
         assert mock_log_exception_traceback.call_count == 2
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
         assert task.get_cmis_host_lanes_mask.call_count == 0
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.subscribe_port_config_change', MagicMock(side_effect = NotImplementedError))
@@ -444,7 +444,7 @@ class TestXcvrdScript(object):
     def test_is_cmis_api(self, mock_class, expected_return_value):
         mock_xcvr_api = MagicMock()
         mock_xcvr_api.__class__ = mock_class
-        assert common.is_cmis_api(mock_xcvr_api) == expected_return_value
+        assert xcvrd_common.is_cmis_api(mock_xcvr_api) == expected_return_value
 
     def test_get_state_db_port_table_val_by_key(self):
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
@@ -474,12 +474,11 @@ class TestXcvrdScript(object):
         assert not xcvr_table_helper.is_npu_si_settings_update_required("Ethernet0", port_mapping)
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_transceiver_firmware_info', MagicMock(return_value={'active_firmware': '2.1.1',
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_transceiver_firmware_info', MagicMock(return_value={'active_firmware': '2.1.1',
                                                                               'inactive_firmware': '1.2.4'}))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_is_flat_memory', MagicMock(return_value=False))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence')
-    def test_post_port_sfp_firmware_info_to_db(self, mock_get_presence):
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_is_flat_memory')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence')
+    def test_post_port_sfp_firmware_info_to_db(self, mock_get_presence, mock_is_flat_memory):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
         port_mapping.get_physical_to_logical = MagicMock(return_value=["Ethernet0", "Ethernet4"])
@@ -1146,8 +1145,8 @@ class TestXcvrdScript(object):
         assert status_db_utils._update_flag_metadata_tables.call_count == 0
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_transceiver_pm', MagicMock(return_value={'prefec_ber_avg': '0.0003407240007014899',
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_transceiver_pm', MagicMock(return_value={'prefec_ber_avg': '0.0003407240007014899',
                                                                               'prefec_ber_min': '0.0006814479342250317',
                                                                               'prefec_ber_max': '0.0006833674050752236',
                                                                               'uncorr_frames_avg': '0.0',
@@ -1166,7 +1165,7 @@ class TestXcvrdScript(object):
         assert pm_tbl.get_size_for_key(logical_port_name) == 6
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     def test_del_port_sfp_dom_info_from_db(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
@@ -1175,7 +1174,7 @@ class TestXcvrdScript(object):
         init_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
         pm_tbl = Table("STATE_DB", TRANSCEIVER_PM_TABLE)
         firmware_info_tbl = Table("STATE_DB", TRANSCEIVER_FIRMWARE_INFO_TABLE)
-        common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping, [init_tbl, dom_tbl, dom_threshold_tbl, pm_tbl, firmware_info_tbl])
+        xcvrd_common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping, [init_tbl, dom_tbl, dom_threshold_tbl, pm_tbl, firmware_info_tbl])
         assert dom_tbl.get_size() == 0
 
     @pytest.mark.parametrize("mock_found, mock_state, expected_cmis_state", [
@@ -1185,10 +1184,10 @@ class TestXcvrdScript(object):
     def test_get_cmis_state_from_state_db(self, mock_found, mock_state, expected_cmis_state):
         status_tbl = MagicMock()
         status_tbl.hget.return_value = (mock_found, mock_state)
-        assert common.get_cmis_state_from_state_db("Ethernet0", status_tbl) == expected_cmis_state
+        assert xcvrd_common.get_cmis_state_from_state_db("Ethernet0", status_tbl) == expected_cmis_state
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_info', MagicMock(return_value={'type': '22.75',
                                                                                 'vendor_rev': '0.5',
@@ -1240,7 +1239,7 @@ class TestXcvrdScript(object):
         post_port_sfp_info_to_db(logical_port_name, port_mapping, dom_tbl, transceiver_dict, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=False))
     def test_post_port_sfp_info_to_db_with_sfp_not_present(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
@@ -1248,11 +1247,11 @@ class TestXcvrdScript(object):
         intf_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
         transceiver_dict = {}
         post_port_sfp_info_to_db(logical_port_name, port_mapping, intf_tbl , transceiver_dict, stop_event)
-        assert common._wrapper_get_presence.call_count == 1
+        assert xcvrd_common._wrapper_get_presence.call_count == 1
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_info', MagicMock(return_value={'type': '22.75',
@@ -1287,7 +1286,7 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     def test_init_port_sfp_status_sw_tbl(self):
@@ -1310,7 +1309,7 @@ class TestXcvrdScript(object):
         assert optics_si_parser.load_optics_si_settings() == {}
 
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.is_cmis_api')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_cmis_api')
     def test_get_media_settings_key(self, mock_is_cmis_api, mock_chassis):
         mock_sfp = MagicMock()
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
@@ -1513,7 +1512,7 @@ class TestXcvrdScript(object):
         result = media_settings_parser.get_is_copper(0)
         assert result == True
 
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_cfg_port_tbl', MagicMock())
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_optic_copper_si)
@@ -1558,10 +1557,10 @@ class TestXcvrdScript(object):
         self._check_notify_media_setting(1, False, None, {})
 
         # Test with sfp not present
-        with patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=False)):
+        with patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=False)):
             self._check_notify_media_setting(1)
 
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_cfg_port_tbl', MagicMock())
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_with_comma_dict)
@@ -1600,31 +1599,31 @@ class TestXcvrdScript(object):
         assert result_dict == expected_value
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', optics_si_settings_dict)
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     def test_fetch_optics_si_setting(self):
         self._check_fetch_optics_si_setting(1)
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', optics_si_settings_with_comma_dict)
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     def test_fetch_optics_si_setting_with_comma(self):
         self._check_fetch_optics_si_setting(1)
         self._check_fetch_optics_si_setting(6)
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', port_optics_si_settings)
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     def test_fetch_optics_si_setting_with_port(self):
         self._check_fetch_optics_si_setting(1)
 
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.g_optics_si_dict', port_optics_si_settings)
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.get_module_vendor_key', MagicMock(return_value=(None, None)))
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     def test_fetch_optics_si_setting_negative(self):
         port = 1
         lane_speed = 100
         mock_sfp = MagicMock()
         assert not optics_si_parser.fetch_optics_si_setting(port, lane_speed, mock_sfp)
 
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.get_module_vendor_key', MagicMock(return_value=('CREDO-CAC82X321M','CREDO')))
     def _check_fetch_optics_si_setting(self, index):
         port = 1
@@ -2006,8 +2005,8 @@ class TestXcvrdScript(object):
             ([], [], []),
         ],
     )
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence')
     def test_remove_stale_transceiver_info(self, mock_get_presence, mock_del_port_sfp_dom_info_from_db,
                                            logical_ports, transceiver_presence, expected_removed_ports):
         # Mock the DaemonXcvrd class and its dependencies
@@ -2426,8 +2425,8 @@ class TestXcvrdScript(object):
         assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
-    @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
+    @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     def test_CmisManagerTask_task_run_stop(self, mock_chassis):
         mock_object = MagicMock()
         mock_object.get_presence = MagicMock(return_value=True)
@@ -2536,9 +2535,9 @@ class TestXcvrdScript(object):
         ('Unknown Interface', 0)
     ])
     def test_get_interface_speed(self, ifname, expected):
-        assert common.get_interface_speed(ifname) == expected
+        assert xcvrd_common.get_interface_speed(ifname) == expected
 
-    @patch('xcvrd.xcvrd_utilities.common.is_cmis_api', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_cmis_api', MagicMock(return_value=True))
     @pytest.mark.parametrize("host_lane_count, speed, subport, expected", [
         (8, 400000, 0, 0xFF),
         (4, 100000, 1, 0xF),
@@ -2582,7 +2581,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event, platform_chassis=MagicMock())
 
-        appl = common.get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
+        appl = xcvrd_common.get_cmis_application_desired(mock_xcvr_api, host_lane_count, speed)
         assert task.get_cmis_host_lanes_mask(mock_xcvr_api, appl, host_lane_count, subport) == expected
 
     @pytest.mark.parametrize("gearbox_data, expected_dict", [
@@ -2929,12 +2928,12 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
-    @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
+    @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
-    @patch('xcvrd.cmis.CmisManagerTask.wait_for_port_config_done', MagicMock())
-    @patch('xcvrd.cmis.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
-    @patch('xcvrd.xcvrd_utilities.common.is_cmis_api', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
+    @patch('xcvrd.xcvrd.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_cmis_api', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.optics_si_present', MagicMock(return_value=(True)))
     @patch('xcvrd.xcvrd_utilities.optics_si_parser.fetch_optics_si_setting', MagicMock())
     def test_CmisManagerTask_task_worker(self, mock_chassis, mock_get_status_sw_tbl):
@@ -3121,7 +3120,7 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_sw_tbl.return_value = mock_get_status_sw_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_UNKNOWN
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_UNKNOWN
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -3131,7 +3130,7 @@ class TestXcvrdScript(object):
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
 
         task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
@@ -3140,45 +3139,45 @@ class TestXcvrdScript(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
 
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
         task.configure_tx_output_power = MagicMock(return_value=1)
         task.configure_laser_frequency = MagicMock(return_value=1)
 
         # Case 1: CMIS_STATE_DP_PRE_INIT_CHECK --> DP_DEINIT
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert mock_xcvr_api.set_datapath_deinit.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert mock_xcvr_api.set_lpmode.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_AP_CONF
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_AP_CONF
 
         # Case 2: DP_DEINIT --> AP Configured
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert mock_xcvr_api.set_application.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_INIT
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_INIT
 
         # Case 3: AP Configured --> DP_INIT
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert mock_xcvr_api.set_datapath_init.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_TXON
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_TXON
 
         # Case 4: DP_INIT --> DP_TXON
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert mock_xcvr_api.tx_disable_channel.call_count == 2
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_ACTIVATE
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_ACTIVATE
 
         # Case 5: DP_TXON --> DP_ACTIVATION
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.post_port_active_apsel_to_db = MagicMock()
         task.task_worker()
         assert task.post_port_active_apsel_to_db.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
 
         # Fail test coverage - Module Inserted state failing to reach DP_DEINIT
         port_mapping = PortMapping()
@@ -3189,7 +3188,7 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_sw_tbl.return_value = mock_get_status_sw_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_UNKNOWN
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_UNKNOWN
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -3199,7 +3198,7 @@ class TestXcvrdScript(object):
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
-        assert common.get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet1', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet1'))) == CMIS_STATE_INSERTED
 
         task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
@@ -3210,12 +3209,12 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=(True)))
-    @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_fast_reboot_enabled', MagicMock(return_value=(True)))
+    @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
-    @patch('xcvrd.cmis.CmisManagerTask.wait_for_port_config_done', MagicMock())
-    @patch('xcvrd.cmis.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
-    @patch('xcvrd.xcvrd_utilities.common.is_cmis_api', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
+    @patch('xcvrd.xcvrd.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_cmis_api', MagicMock(return_value=True))
     def test_CmisManagerTask_task_worker_fastboot(self, mock_chassis, mock_get_status_sw_tbl):
         mock_get_status_sw_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_SW_TABLE)
         mock_xcvr_api = MagicMock()
@@ -3320,7 +3319,7 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_sw_tbl.return_value = mock_get_status_sw_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_UNKNOWN
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_UNKNOWN
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -3330,7 +3329,7 @@ class TestXcvrdScript(object):
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
 
         task.get_host_tx_status = MagicMock(return_value='false')
         task.get_port_admin_status = MagicMock(return_value='up')
@@ -3345,16 +3344,16 @@ class TestXcvrdScript(object):
 
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert task.post_port_active_apsel_to_db.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
-    @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
+    @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
-    @patch('xcvrd.cmis.CmisManagerTask.wait_for_port_config_done', MagicMock())
-    @patch('xcvrd.cmis.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
-    @patch('xcvrd.xcvrd_utilities.common.is_cmis_api', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
+    @patch('xcvrd.xcvrd.CmisManagerTask.is_decommission_required', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_cmis_api', MagicMock(return_value=True))
     def test_CmisManagerTask_task_worker_host_tx_ready_false_to_true(self, mock_chassis, mock_get_status_sw_tbl):
         mock_get_status_sw_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_TABLE)
         mock_xcvr_api = MagicMock()
@@ -3499,7 +3498,7 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_sw_tbl.return_value = mock_get_status_sw_tbl
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_UNKNOWN
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_UNKNOWN
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -3509,7 +3508,7 @@ class TestXcvrdScript(object):
                                             {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
 
         task.get_host_tx_status = MagicMock(return_value='false')
         task.get_port_admin_status = MagicMock(return_value='up')
@@ -3524,14 +3523,14 @@ class TestXcvrdScript(object):
 
         assert task.post_port_active_apsel_to_db.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
         assert task.port_dict['Ethernet0']['forced_tx_disabled'] == True
 
         task.port_dict['Ethernet0']['host_tx_ready'] = 'true'
         task.force_cmis_reinit('Ethernet0', 0)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
 
         # Failure scenario wherein DP state is still DataPathActivated in the first attempt post enabling host_tx_ready
         # This doesn't allow the CMIS state to proceed to DP_DEINIT
@@ -3539,7 +3538,7 @@ class TestXcvrdScript(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, False, False, True])
         task.task_worker()
         assert task.port_dict['Ethernet0']['cmis_retries'] == 1
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_PRE_INIT_CHECK
 
         # Ensures that CMIS state is set to DP_DEINIT in the second attempt
         mock_sfp = MagicMock()
@@ -3548,18 +3547,18 @@ class TestXcvrdScript(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
 
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
         assert task.port_dict['Ethernet0']['forced_tx_disabled'] == False
         assert task.port_dict['Ethernet0']['cmis_retries'] == 1
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
-    @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
+    @patch('xcvrd.xcvrd.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
-    @patch('xcvrd.cmis.CmisManagerTask.wait_for_port_config_done', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.common.is_cmis_api', MagicMock(return_value=True))
-    @patch('xcvrd.xcvrd_utilities.common.get_cmis_application_desired', MagicMock(return_value=1))
+    @patch('xcvrd.xcvrd.CmisManagerTask.wait_for_port_config_done', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_cmis_api', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.get_cmis_application_desired', MagicMock(return_value=1))
     def test_CmisManagerTask_task_worker_decommission(self, mock_chassis, mock_get_status_sw_tbl):
         mock_get_status_sw_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_TABLE)
         mock_xcvr_api = MagicMock()
@@ -3614,12 +3613,12 @@ class TestXcvrdScript(object):
         # Insert 1st subport event
         port_change_event = PortChangeEvent('Ethernet0', physical_port_idx, 0, PortChangeEvent.PORT_SET, {'speed':'100000', 'lanes':'1,2', 'subport': '1'})
         task.on_port_update_event(port_change_event)
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
 
         # 1st subport (as the lead) starting decommission state machine
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*2 + [True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_DEINIT
         assert task.is_decomm_lead_lport('Ethernet0')
 
         # Insert 2nd subport event
@@ -3627,25 +3626,25 @@ class TestXcvrdScript(object):
         task.on_port_update_event(port_change_event)
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*3 + [True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_AP_CONF
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_AP_CONF
         # 2nd subport should not start decommission state machine as 1st subport already started decommission for the entire physical port
-        assert common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_INSERTED
         assert task.is_decomm_pending('Ethernet0')
         assert not task.is_decomm_failed('Ethernet0')
 
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*3 + [True])
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_INIT
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_DP_INIT
         # 2nd subport is waiting for decommission to complete
-        assert common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_INSERTED
         assert task.is_decomm_lead_lport('Ethernet0')
 
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*3 + [True])
         task.task_worker()
         # 1st subport completed decommission state machine and proceed to normal state machine, entire physical port is done on decommission
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_INSERTED
         # 2nd subport is unblocked from decommission and continue on normal state machine
-        assert common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_DP_PRE_INIT_CHECK
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_DP_PRE_INIT_CHECK
         assert not task.is_decomm_lead_lport('Ethernet0')
         assert not task.is_decomm_failed('Ethernet0')
         assert not task.is_decomm_pending('Ethernet0')
@@ -3659,8 +3658,8 @@ class TestXcvrdScript(object):
         mock_xcvr_api.get_datapath_state = MagicMock(return_value=gen_cmis_dp_state_dict('DataPathActivated'))
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*10 + [True]*2)
         task.task_worker()
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
-        assert common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_READY
 
         # Delete the config for all subports
         port_change_event = PortChangeEvent('Ethernet0', physical_port_idx, 0, PortChangeEvent.PORT_DEL, {}, db_name='CONFIG_DB', table_name='PORT')
@@ -3687,7 +3686,7 @@ class TestXcvrdScript(object):
         task.task_worker()
         assert task.is_decomm_lead_lport('Ethernet0')
         # 1st subport should fail on 'ConfigSuccess' check and fall into failed state after retries
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
         assert task.is_decomm_failed('Ethernet0')
 
         # Insert 2nd subport event
@@ -3696,11 +3695,11 @@ class TestXcvrdScript(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False]*10 + [True]*2)
         task.task_worker()
         # 1st subport should stay in failed state
-        assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_FAILED
         assert task.is_decomm_failed('Ethernet0')
         assert task.is_decomm_lead_lport('Ethernet0')
         # 2nd subport is waiting for decommission to complete, and should also fall into failed state
-        assert common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_FAILED
+        assert xcvrd_common.get_cmis_state_from_state_db('Ethernet2', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet2'))) == CMIS_STATE_FAILED
         assert task.is_decomm_pending('Ethernet2')
         assert task.is_decomm_failed('Ethernet2')
 
@@ -3756,7 +3755,7 @@ class TestXcvrdScript(object):
         (False, False, CMIS_STATE_UNKNOWN, True),
         (False, True, None, False),
     ])
-    @patch('xcvrd.xcvrd_utilities.common.get_cmis_state_from_state_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.get_cmis_state_from_state_db')
     def test_DomInfoUpdateTask_is_port_in_cmis_initialization_process(self, mock_get_cmis_state_from_state_db, skip_cmis_manager, is_asic_index_none, mock_cmis_state, expected_result):
         port_mapping = PortMapping()
         lport = 'Ethernet0'
@@ -3810,7 +3809,7 @@ class TestXcvrdScript(object):
         assert dom_info_dict == expected_dom_info_dict
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
     def test_DomInfoUpdateTask_handle_port_change_event(self, mock_del_port_sfp_dom_info_from_db):
         port_mapping = PortMapping()
         mock_sfp_obj_dict = MagicMock()
@@ -3848,7 +3847,7 @@ class TestXcvrdScript(object):
         assert not task.is_alive()
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))
     @patch('xcvrd.xcvrd_utilities.sfp_status_helper.detect_port_in_error_status')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
@@ -3916,7 +3915,7 @@ class TestXcvrdScript(object):
         assert mock_post_pm_info.call_count == 1
 
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.sfp_status_helper.detect_port_in_error_status', MagicMock(return_value=False))
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db', MagicMock(return_value=True))
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
@@ -4059,9 +4058,9 @@ class TestXcvrdScript(object):
             if vdm_supported:
                 assert task.vdm_db_utils.post_port_vdm_flags_to_db.call_count == 1
 
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd.XcvrTableHelper')
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
     def test_SfpStateUpdateTask_handle_port_change_event(self, mock_del_port_sfp_dom_info_from_db, mock_table_helper):
         mock_table = MagicMock()
         mock_table.get = MagicMock(return_value=(False, None))
@@ -4191,11 +4190,11 @@ class TestXcvrdScript(object):
     @patch('os.kill')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._mapping_event_from_change_event')
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
-    @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.update_port_transceiver_status_table_sw')
     def test_SfpStateUpdateTask_task_worker(self, mock_update_status, mock_post_sfp_info,
                                             mock_post_firmware_info, mock_update_media_setting,
                                             mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill):
@@ -4290,10 +4289,10 @@ class TestXcvrdScript(object):
         assert mock_del_dom.call_count == 1
 
     @patch('xcvrd.xcvrd.XcvrTableHelper')
-    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common._wrapper_get_presence')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
-    @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.update_port_transceiver_status_table_sw')
     def test_SfpStateUpdateTask_on_add_logical_port(self, mock_update_status, mock_post_sfp_info,
             mock_update_media_setting, mock_get_presence, mock_table_helper):
         class MockTable:
@@ -4397,13 +4396,13 @@ class TestXcvrdScript(object):
 
         assert port_dict == removal
 
-    @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.platform_sfputil')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_chassis')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_sfputil')
     def test_wrapper_get_presence(self, mock_sfputil, mock_chassis):
         mock_object = MagicMock()
         mock_object.get_presence = MagicMock(return_value=True)
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
-        from xcvrd.xcvrd_utilities.common import _wrapper_get_presence
+        from xcvrd.xcvrd_utilities.xcvrd_common import _wrapper_get_presence
         assert _wrapper_get_presence(1)
 
         mock_object.get_presence = MagicMock(return_value=False)
@@ -4534,20 +4533,20 @@ class TestXcvrdScript(object):
         mock_sfp.get_sfp.side_effect = NotImplementedError
         assert vdm_utils.get_vdm_flags(1) == {}
 
-    @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.common.platform_sfputil')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_chassis')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_sfputil')
     def test_wrapper_get_transceiver_firmware_info(self, mock_sfputil, mock_chassis):
         mock_object = MagicMock()
         mock_object.get_transceiver_dom_real_value = MagicMock(return_value=True)
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
-        from xcvrd.xcvrd_utilities.common import _wrapper_get_transceiver_firmware_info
-        assert common._wrapper_get_transceiver_firmware_info(1)
+        from xcvrd.xcvrd_utilities.xcvrd_common import _wrapper_get_transceiver_firmware_info
+        assert xcvrd_common._wrapper_get_transceiver_firmware_info(1)
 
         mock_object.get_transceiver_info_firmware_versions = MagicMock(return_value={})
-        assert common._wrapper_get_transceiver_firmware_info(1) == {}
+        assert xcvrd_common._wrapper_get_transceiver_firmware_info(1) == {}
 
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
-        assert common._wrapper_get_transceiver_firmware_info(1) == {}
+        assert xcvrd_common._wrapper_get_transceiver_firmware_info(1) == {}
 
     def test_get_transceiver_dom_sensor_real_value(self):
         mock_sfp = MagicMock()
@@ -4614,12 +4613,12 @@ class TestXcvrdScript(object):
         mock_sfp.get_transceiver_status_flags.side_effect = NotImplementedError
         assert status_utils.get_transceiver_status_flags(1) == {}
 
-    @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_chassis')
     def test_wrapper_get_transceiver_pm(self, mock_chassis):
         mock_object = MagicMock()
         mock_object.get_transceiver_pm = MagicMock(return_value=True)
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
-        from xcvrd.xcvrd_utilities.common import _wrapper_get_transceiver_pm
+        from xcvrd.xcvrd_utilities.xcvrd_common import _wrapper_get_transceiver_pm
         assert _wrapper_get_transceiver_pm(1)
 
         mock_object.get_transceiver_pm = MagicMock(return_value=False)
@@ -4662,7 +4661,7 @@ class TestXcvrdScript(object):
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
         assert not _wrapper_get_sfp_error_description(1)
 
-    @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_chassis')
     def test_wrapper_is_flat_memory(self, mock_chassis):
         mock_api = MagicMock()
         mock_api.is_flat_memory = MagicMock(return_value=True)
@@ -4670,34 +4669,34 @@ class TestXcvrdScript(object):
         mock_object.get_xcvr_api = MagicMock(return_value=mock_api)
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
 
-        from xcvrd.xcvrd_utilities.common import _wrapper_is_flat_memory
+        from xcvrd.xcvrd_utilities.xcvrd_common import _wrapper_is_flat_memory
         assert _wrapper_is_flat_memory(1) == True
 
         mock_chassis.get_sfp = MagicMock(side_effect=NotImplementedError)
         assert not _wrapper_is_flat_memory(1)
 
-    @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.platform_chassis')
     def test_wrapper_is_flat_memory_no_xcvr_api(self, mock_chassis):
         mock_object = MagicMock()
         mock_object.get_xcvr_api = MagicMock(return_value=None)
         mock_chassis.get_sfp = MagicMock(return_value=mock_object)
 
-        from xcvrd.xcvrd_utilities.common import _wrapper_is_flat_memory
+        from xcvrd.xcvrd_utilities.xcvrd_common import _wrapper_is_flat_memory
         assert _wrapper_is_flat_memory(1) == True
 
     def test_check_port_in_range(self):
         range_str = '1 - 32'
         physical_port = 1
-        assert common.check_port_in_range(range_str, physical_port)
+        assert xcvrd_common.check_port_in_range(range_str, physical_port)
 
         physical_port = 32
-        assert common.check_port_in_range(range_str, physical_port)
+        assert xcvrd_common.check_port_in_range(range_str, physical_port)
 
         physical_port = 0
-        assert not common.check_port_in_range(range_str, physical_port)
+        assert not xcvrd_common.check_port_in_range(range_str, physical_port)
 
         physical_port = 33
-        assert not common.check_port_in_range(range_str, physical_port)
+        assert not xcvrd_common.check_port_in_range(range_str, physical_port)
 
     def test_get_serdes_si_setting_val_str(self):
         lane_dict = {'lane0': '1', 'lane1': '2', 'lane2': '3', 'lane3': '4'}
@@ -4745,7 +4744,7 @@ class TestXcvrdScript(object):
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', '/tmp')))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
     def test_DaemonXcvrd_init_deinit_fastboot_enabled(self, mock_del_port_sfp_dom_info_from_db):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
         with patch("subprocess.check_output") as mock_run:
@@ -4786,11 +4785,11 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
     @patch('xcvrd.xcvrd_utilities.port_event_helper.get_port_mapping', MagicMock(return_value=MockPortMapping))
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', '/tmp')))
-    @patch('xcvrd.xcvrd_utilities.common.is_warm_reboot_enabled', MagicMock(return_value=False))
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.is_warm_reboot_enabled', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.initialize_sfp_obj_dict', MagicMock())
     @patch('subprocess.check_output', MagicMock(return_value='false'))
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
     def test_DaemonXcvrd_init_deinit_cold(self, mock_del_port_sfp_dom_info_from_db):
         xcvrd.platform_chassis = MagicMock()
 
@@ -5015,11 +5014,11 @@ class TestXcvrdScript(object):
     @patch('os.kill')
     @patch('xcvrd.xcvrd.SfpStateUpdateTask._mapping_event_from_change_event')
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
-    @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
     @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
-    @patch('xcvrd.xcvrd_utilities.common.update_port_transceiver_status_table_sw')
+    @patch('xcvrd.xcvrd_utilities.xcvrd_common.update_port_transceiver_status_table_sw')
     @patch('xcvrd.xcvrd.platform_chassis')
     def test_sfp_removal_from_dict(self, mock_platform_chassis, mock_update_status, mock_post_sfp_info,
                                             mock_post_firmware_info, mock_update_media_setting,

--- a/sonic-xcvrd/xcvrd/cmis/__init__.py
+++ b/sonic-xcvrd/xcvrd/cmis/__init__.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+
+"""
+    cmis
+    CMIS transceiver management module for SONiC
+"""
+
 from .cmis_manager_task import CmisManagerTask
 
 __all__ = ['CmisManagerTask']

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -157,7 +157,6 @@ class CmisManagerTask(threading.Thread):
     def get_cmis_module_power_down_duration_secs(self, api):
         return api.get_module_pwr_down_duration()/1000
 
->>>>>>> 77b86d4 (Move CmisManagerTask into it's own module)
     def get_cmis_host_lanes_mask(self, api, appl, host_lane_count, subport):
         """
         Retrieves mask of active host lanes based on appl, host lane count and subport
@@ -890,7 +889,6 @@ class CmisManagerTask(threading.Thread):
                             ec = 1
 
                 # D.1.3 Software Configuration and Initialization
-                breakpoint()
                 api.set_application(host_lanes_mask, appl, ec)
                 if not api.scs_apply_datapath_init(host_lanes_mask):
                     self.log_notice("{}: unable to set application and stage DP init".format(lport))

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -653,9 +653,403 @@ class CmisManagerTask(threading.Thread):
 
         return expired_time <= current_time
 
-    def task_worker(self):
+    def process_cmis_state_machine(self, lport):
+        port_info = self.port_dict[lport]
+        state = common.get_cmis_state_from_state_db(lport, self.xcvr_table_helper.get_status_sw_tbl(self.get_asic_id(lport)))
+        speed = port_info.get('speed')
+        api = port_info.get('api')
+        host_lane_count = port_info.get('host_lane_count')
+        subport = port_info.get('subport')
+        pport = port_info.get('pport')
+        sfp = port_info.get('sfp')
         is_fast_reboot = common.is_fast_reboot_enabled()
 
+        # CMIS expiration and retries
+        #
+        # A retry should always start over at INSETRTED state, while the
+        # expiration will reset the state to INSETRTED and advance the
+        # retry counter
+        expired = port_info.get('cmis_expired')
+        retries = port_info.get('cmis_retries', 0)
+        host_lanes_mask = port_info.get('host_lanes_mask', 0)
+        appl = port_info.get('appl', 0)
+        # appl can be 0 if this lport is in decommission state machine, which should not be considered as failed case.
+        if state != CMIS_STATE_INSERTED and not self.is_decomm_lead_lport(lport) and (host_lanes_mask <= 0 or appl < 1):
+            self.log_error("{}: Unexpected value for host_lanes_mask {} or appl {} in "
+                            "{} state".format(lport, host_lanes_mask, appl, state))
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+            return
+
+        self.log_notice("{}: {}G, lanemask=0x{:x}, CMIS state={}{}, Module state={}, DP state={}, appl {} host_lane_count {} "
+                        "retries={}".format(lport, int(speed/1000), host_lanes_mask, state,
+                        "(decommission" + ("*" if self.is_decomm_lead_lport(lport) else "") + ")"
+                            if self.is_decomm_pending(lport) else "",
+                        api.get_module_state(), api.get_datapath_state(), appl, host_lane_count, retries))
+        if retries > self.CMIS_MAX_RETRIES:
+            self.log_error("{}: FAILED".format(lport))
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+            return
+
+        try:
+            # CMIS state transitions
+            if state == CMIS_STATE_INSERTED:
+                self.port_dict[lport]['appl'] = common.get_cmis_application_desired(api, host_lane_count, speed)
+                if self.port_dict[lport]['appl'] is None:
+                    self.log_error("{}: no suitable app for the port appl {} host_lane_count {} "
+                                    "host_speed {}".format(lport, appl, host_lane_count, speed))
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                    return
+                appl = self.port_dict[lport]['appl']
+                self.log_notice("{}: Setting appl={}".format(lport, appl))
+
+                self.port_dict[lport]['host_lanes_mask'] = self.get_cmis_host_lanes_mask(api,
+                                                                appl, host_lane_count, subport)
+                if self.port_dict[lport]['host_lanes_mask'] <= 0:
+                    self.log_error("{}: Invalid lane mask received - host_lane_count {} subport {} "
+                                    "appl {}!".format(lport, host_lane_count, subport, appl))
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                    return
+                host_lanes_mask = self.port_dict[lport]['host_lanes_mask']
+                self.log_notice("{}: Setting host_lanemask=0x{:x}".format(lport, host_lanes_mask))
+
+                self.port_dict[lport]['media_lane_count'] = int(api.get_media_lane_count(appl))
+                self.port_dict[lport]['media_lane_assignment_options'] = int(api.get_media_lane_assignment_option(appl))
+                media_lane_count = self.port_dict[lport]['media_lane_count']
+                media_lane_assignment_options = self.port_dict[lport]['media_lane_assignment_options']
+                self.port_dict[lport]['media_lanes_mask'] = self.get_cmis_media_lanes_mask(api,
+                                                                appl, lport, subport)
+                if self.port_dict[lport]['media_lanes_mask'] <= 0:
+                    self.log_error("{}: Invalid media lane mask received - media_lane_count {} "
+                                    "media_lane_assignment_options {} subport {}"
+                                    " appl {}!".format(lport, media_lane_count, media_lane_assignment_options, subport, appl))
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                    return
+                media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
+                self.log_notice("{}: Setting media_lanemask=0x{:x}".format(lport, media_lanes_mask))
+
+                if self.is_decommission_required(api, appl):
+                    self.set_decomm_pending(lport)
+
+                if self.is_decomm_lead_lport(lport):
+                    # Set all the DP lanes AppSel to unused(0) when non default app code needs to be configured
+                    self.port_dict[lport]['appl'] = appl = 0
+                    self.port_dict[lport]['host_lanes_mask'] = host_lanes_mask = self.ALL_LANES_MASK
+                    self.port_dict[lport]['media_lanes_mask'] = self.ALL_LANES_MASK
+                    self.log_notice("{}: DECOMMISSION: setting appl={} and "
+                                    "host_lanes_mask/media_lanes_mask={:#x}".format(lport, appl, self.ALL_LANES_MASK))
+                    # Skip rest of the deinit/pre-init when this is the lead logical port for decommission
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
+                    return
+                elif self.is_decomm_pending(lport):
+                    if self.is_decomm_failed(lport):
+                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                        decomm_status_str = "failed"
+                    else:
+                        decomm_status_str = "waiting for completion"
+                    self.log_notice("{}: DECOMMISSION: decommission has already started for this physical port, "
+                                    "{}".format(lport, decomm_status_str))
+                    return
+
+                if self.port_dict[lport]['host_tx_ready'] != 'true' or \
+                        self.port_dict[lport]['admin_status'] != 'up':
+                    if is_fast_reboot and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
+                        self.log_notice("{} Skip datapath re-init in fast-reboot".format(lport))
+                    else:
+                        self.log_notice("{} Forcing Tx laser OFF".format(lport))
+                        # Force DataPath re-init
+                        api.tx_disable_channel(media_lanes_mask, True)
+                        self.port_dict[lport]['forced_tx_disabled'] = True
+                        txoff_duration = self.get_cmis_dp_tx_turnoff_duration_secs(api)
+                        self.log_notice("{}: Tx turn off duration {} secs".format(lport, txoff_duration))
+                        self.update_cmis_state_expiration_time(lport, txoff_duration)
+                        self.post_port_active_apsel_to_db(api, lport, host_lanes_mask, reset_apsel=True)
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                    return
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_PRE_INIT_CHECK)
+            if state == CMIS_STATE_DP_PRE_INIT_CHECK:
+                if self.port_dict[lport].get('forced_tx_disabled', False):
+                    # Ensure that Tx is OFF
+                    # Transceiver will remain in DataPathDeactivated state while it is in Low Power Mode (even if Tx is disabled)
+                    # Transceiver will enter DataPathInitialized state if Tx was disabled after CMIS initialization was completed
+                    if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated', 'DataPathInitialized']):
+                        if self.is_timer_expired(expired):
+                            self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized'".format(lport))
+                            self.force_cmis_reinit(lport, retries + 1)
+                        return
+                    self.port_dict[lport]['forced_tx_disabled'] = False
+                    self.log_notice("{}: Tx laser is successfully turned OFF".format(lport))
+
+                # Configure the target output power if ZR module
+                if api.is_coherent_module():
+                    tx_power = self.port_dict[lport]['tx_power']
+                    # Prevent configuring same tx power multiple times
+                    if 0 != tx_power and tx_power != api.get_tx_config_power():
+                        if 1 != self.configure_tx_output_power(api, lport, tx_power):
+                            self.log_error("{} failed to configure Tx power = {}".format(lport, tx_power))
+                        else:
+                            self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
+
+                need_update = self.is_cmis_application_update_required(api, appl, host_lanes_mask)
+
+                # For ZR module, Datapath needes to be re-initlialized on new channel selection
+                if api.is_coherent_module():
+                    freq = self.port_dict[lport]['laser_freq']
+                    # If user requested frequency is NOT the same as configured on the module
+                    # force datapath re-initialization
+                    if 0 != freq and freq != api.get_laser_config_freq():
+                        if self.validate_frequency_and_grid(api, lport, freq) == True:
+                            need_update = True
+                        else:
+                            # clear setting of invalid frequency config
+                            self.port_dict[lport]['laser_freq'] = 0
+
+                if not need_update:
+                    # No application updates
+                    # As part of xcvrd restart, the TRANSCEIVER_INFO table is deleted and
+                    # created with default value of 'N/A' for all the active apsel fields.
+                    # The below (post_port_active_apsel_to_db) will ensure that the
+                    # active apsel fields are updated correctly in the DB since
+                    # the CMIS state remains unchanged during xcvrd restart
+                    self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
+                    self.log_notice("{}: no CMIS application update required...READY".format(lport))
+                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                    return
+                self.log_notice("{}: force Datapath reinit".format(lport))
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
+            elif state == CMIS_STATE_DP_DEINIT:
+                # D.2.2 Software Deinitialization
+                api.set_datapath_deinit(host_lanes_mask)
+
+                # D.1.3 Software Configuration and Initialization
+                media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
+                if not api.tx_disable_channel(media_lanes_mask, True):
+                    self.log_notice("{}: unable to turn off tx power with host_lanes_mask {}".format(lport, host_lanes_mask))
+                    self.port_dict[lport]['cmis_retries'] = retries + 1
+                    return
+
+                #Sets module to high power mode and doesn't impact datapath if module is already in high power mode
+                api.set_lpmode(False, wait_state_change = False)
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_AP_CONF)
+                dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
+                modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)
+                self.log_notice("{}: DpDeinit duration {} secs, modulePwrUp duration {} secs".format(lport, dpDeinitDuration, modulePwrUpDuration))
+                self.update_cmis_state_expiration_time(lport, max(modulePwrUpDuration, dpDeinitDuration))
+
+            elif state == CMIS_STATE_AP_CONF:
+                # Explicit control bit to apply custom Host SI settings. 
+                # It will be set to 1 and applied via set_application if 
+                # custom SI settings is applicable
+                ec = 0
+
+                # TODO: Use fine grained time when the CMIS memory map is available
+                if not self.check_module_state(api, ['ModuleReady']):
+                    if self.is_timer_expired(expired):
+                        self.log_notice("{}: timeout for 'ModuleReady'".format(lport))
+                        self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated']):
+                    if self.is_timer_expired(expired):
+                        self.log_notice("{}: timeout for 'DataPathDeactivated state'".format(lport))
+                        self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                # Skip rest if it's in decommission state machine
+                if not self.is_decomm_pending(lport):
+                    if api.is_coherent_module():
+                    # For ZR module, configure the laser frequency when Datapath is in Deactivated state
+                        freq = self.port_dict[lport]['laser_freq']
+                        if 0 != freq:
+                            if 1 != self.configure_laser_frequency(api, lport, freq):
+                                self.log_error("{} failed to configure laser frequency {} GHz".format(lport, freq))
+                            else:
+                                self.log_notice("{} configured laser frequency {} GHz".format(lport, freq))
+
+                    # Stage custom SI settings
+                    if optics_si_parser.optics_si_present():
+                        optics_si_dict = {}
+                        # Apply module SI settings if applicable
+                        lane_speed = int(speed/1000)//host_lane_count
+                        optics_si_dict = optics_si_parser.fetch_optics_si_setting(pport, lane_speed, sfp)
+
+                        self.log_debug("Read SI parameters for port {} from optics_si_settings.json vendor file:".format(lport))
+                        for key, sub_dict in optics_si_dict.items():
+                            self.log_debug("{}".format(key))
+                            for sub_key, value in sub_dict.items():
+                                self.log_debug("{}: {}".format(sub_key, str(value)))
+
+                        if optics_si_dict:
+                            self.log_notice("{}: Apply Optics SI found for Vendor: {}  PN: {} lane speed: {}G".
+                                            format(lport, api.get_manufacturer(), api.get_model(), lane_speed))
+                            if not api.stage_custom_si_settings(host_lanes_mask, optics_si_dict):
+                                self.log_notice("{}: unable to stage custom SI settings ".format(lport))
+                                self.force_cmis_reinit(lport, retries + 1)
+                                return
+
+                            # Set Explicit control bit to apply Custom Host SI settings
+                            ec = 1
+
+                # D.1.3 Software Configuration and Initialization
+                breakpoint()
+                api.set_application(host_lanes_mask, appl, ec)
+                if not api.scs_apply_datapath_init(host_lanes_mask):
+                    self.log_notice("{}: unable to set application and stage DP init".format(lport))
+                    self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_INIT)
+            elif state == CMIS_STATE_DP_INIT:
+                if not self.check_config_error(api, host_lanes_mask, ['ConfigSuccess']):
+                    if self.is_timer_expired(expired):
+                        self.log_notice("{}: timeout for 'ConfigSuccess', current ConfigStatus: "
+                                        "{}".format(lport, list(api.get_config_datapath_hostlane_status().values())))
+                        self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                # Clear decommission status and invoke CMIS reinit so that normal CMIS initialization can begin
+                if self.is_decomm_pending(lport):
+                    self.log_notice("{}: DECOMMISSION: done for physical port {}".format(lport, self.port_dict[lport]['index']))
+                    self.clear_decomm_pending(lport)
+                    self.force_cmis_reinit(lport)
+                    return
+
+                if hasattr(api, 'get_cmis_rev'):
+                    # Check datapath init pending on module that supports CMIS 5.x
+                    majorRev = int(api.get_cmis_rev().split('.')[0])
+                    if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes_mask):
+                        self.log_notice("{}: datapath init not pending".format(lport))
+                        self.force_cmis_reinit(lport, retries + 1)
+                        return
+
+                # Ensure the Datapath is NOT Activated unless the host Tx siganl is good.
+                # NOTE: Some CMIS compliant modules may have 'auto-squelch' feature where
+                # the module won't take datapaths to Activated state if host tries to enable
+                # the datapaths while there is no good Tx signal from the host-side.
+                if self.port_dict[lport]['admin_status'] != 'up' or \
+                        self.port_dict[lport]['host_tx_ready'] != 'true':
+                    self.log_notice("{} waiting for host tx ready...".format(lport))
+                    return
+
+                # D.1.3 Software Configuration and Initialization
+                api.set_datapath_init(host_lanes_mask)
+                dpInitDuration = self.get_cmis_dp_init_duration_secs(api)
+                self.log_notice("{}: DpInit duration {} secs".format(lport, dpInitDuration))
+                self.update_cmis_state_expiration_time(lport, dpInitDuration)
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_TXON)
+            elif state == CMIS_STATE_DP_TXON:
+                if not self.check_datapath_state(api, host_lanes_mask, ['DataPathInitialized']):
+                    if self.is_timer_expired(expired):
+                        self.log_notice("{}: timeout for 'DataPathInitialized'".format(lport))
+                        self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                # Turn ON the laser
+                media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
+                api.tx_disable_channel(media_lanes_mask, False)
+                self.log_notice("{}: Turning ON tx power".format(lport))
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_ACTIVATE)
+            elif state == CMIS_STATE_DP_ACTIVATE:
+                # Use dpInitDuration instead of MaxDurationDPTxTurnOn because
+                # some modules rely on dpInitDuration to turn on the Tx signal.
+                # This behavior deviates from the CMIS spec but is honored
+                # to prevent old modules from breaking with new sonic
+                if not self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
+                    if self.is_timer_expired(expired):
+                        self.log_notice("{}: timeout for 'DataPathActivated'".format(lport))
+                        self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                self.log_notice("{}: READY".format(lport))
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
+
+        except Exception as e:
+            self.log_error("{}: internal errors due to {}".format(lport, e))
+            common.log_exception_traceback()
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+
+    def process_single_lport(self, lport, info):
+        state = common.get_cmis_state_from_state_db(lport, self.xcvr_table_helper.get_status_sw_tbl(self.get_asic_id(lport)))
+        if state in CMIS_TERMINAL_STATES or state == CMIS_STATE_UNKNOWN:
+            if state != CMIS_STATE_READY:
+                self.port_dict[lport]['appl'] = 0
+                self.port_dict[lport]['host_lanes_mask'] = 0
+            return
+
+        # Handle the case when Xcvrd was NOT running when 'host_tx_ready' or 'admin_status'
+        # was updated or this is the first run so reconcile the above two attributes
+        if 'host_tx_ready' not in self.port_dict[lport]:
+            self.port_dict[lport]['host_tx_ready'] = self.get_host_tx_status(lport)
+
+        if 'admin_status' not in self.port_dict[lport]:
+            self.port_dict[lport]['admin_status'] = self.get_port_admin_status(lport)
+
+        pport = int(info.get('index', "-1"))
+        speed = int(info.get('speed', "0"))
+        lanes = info.get('lanes', "").strip()
+        subport = info.get('subport', 0)
+        if pport < 0 or speed == 0 or len(lanes) < 1 or subport < 0:
+            return
+
+        # Desired port speed on the host side
+        host_speed = speed
+        host_lane_count = len(lanes.split(','))
+
+        # Store port information in port_dict for use by process_cmis_state_machine
+        self.port_dict[lport]['pport'] = pport
+        self.port_dict[lport]['speed'] = speed
+        self.port_dict[lport]['subport'] = subport
+        self.port_dict[lport]['host_lane_count'] = host_lane_count
+
+        # double-check the HW presence before moving forward
+        sfp = self.platform_chassis.get_sfp(pport)
+        if not sfp.get_presence():
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_REMOVED)
+            return
+
+        try:
+            # Skip if XcvrApi is not supported
+            api = sfp.get_xcvr_api()
+            if api is None:
+                self.log_error("{}: skipping CMIS state machine since no xcvr api!!!".format(lport))
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                return
+
+            # Skip if it's not a paged memory device
+            if api.is_flat_memory():
+                self.log_notice("{}: skipping CMIS state machine for flat memory xcvr".format(lport))
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                return
+
+            # Skip if it's not a CMIS module
+            type = api.get_module_type_abbreviation()
+            if (type is None) or (type not in self.CMIS_MODULE_TYPES):
+                self.log_notice("{}: skipping CMIS state machine for non-CMIS module with type {}".format(lport, type))
+                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                return
+
+            # Store api and sfp in port_dict for use by process_cmis_state_machine
+            self.port_dict[lport]['api'] = api
+            self.port_dict[lport]['sfp'] = sfp
+
+            if api.is_coherent_module():
+                if 'tx_power' not in self.port_dict[lport]:
+                    self.port_dict[lport]['tx_power'] = self.get_configured_tx_power_from_db(lport)
+                if 'laser_freq' not in self.port_dict[lport]:
+                    self.port_dict[lport]['laser_freq'] = self.get_configured_laser_freq_from_db(lport)
+        except AttributeError:
+            # Skip if these essential routines are not available
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+            return
+        except Exception as e:
+            self.log_error("{}: Exception in xcvr api: {}".format(lport, e))
+            common.log_exception_traceback()
+            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+            return
+
+        self.process_cmis_state_machine(lport)
+
+    def task_worker(self):
         # APPL_DB for CONFIG updates, and STATE_DB for insertion/removal
         port_change_observer = PortChangeObserver(self.namespaces, helper_logger,
                                                   self.task_stopping_event,
@@ -672,376 +1066,7 @@ class CmisManagerTask(threading.Thread):
                 if lport not in self.port_dict:
                     continue
 
-                state = common.get_cmis_state_from_state_db(lport, self.xcvr_table_helper.get_status_sw_tbl(self.get_asic_id(lport)))
-                if state in CMIS_TERMINAL_STATES or state == CMIS_STATE_UNKNOWN:
-                    if state != CMIS_STATE_READY:
-                        self.port_dict[lport]['appl'] = 0
-                        self.port_dict[lport]['host_lanes_mask'] = 0
-                    continue
-
-                # Handle the case when Xcvrd was NOT running when 'host_tx_ready' or 'admin_status'
-                # was updated or this is the first run so reconcile the above two attributes
-                if 'host_tx_ready' not in self.port_dict[lport]:
-                   self.port_dict[lport]['host_tx_ready'] = self.get_host_tx_status(lport)
-
-                if 'admin_status' not in self.port_dict[lport]:
-                   self.port_dict[lport]['admin_status'] = self.get_port_admin_status(lport)
-
-                pport = int(info.get('index', "-1"))
-                speed = int(info.get('speed', "0"))
-                lanes = info.get('lanes', "").strip()
-                subport = info.get('subport', 0)
-                if pport < 0 or speed == 0 or len(lanes) < 1 or subport < 0:
-                    continue
-
-                # Desired port speed on the host side
-                host_speed = speed
-                host_lane_count = len(lanes.split(','))
-
-                # double-check the HW presence before moving forward
-                sfp = self.platform_chassis.get_sfp(pport)
-                if not sfp.get_presence():
-                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_REMOVED)
-                    continue
-
-                try:
-                    # Skip if XcvrApi is not supported
-                    api = sfp.get_xcvr_api()
-                    if api is None:
-                        self.log_error("{}: skipping CMIS state machine since no xcvr api!!!".format(lport))
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                        continue
-
-                    # Skip if it's not a paged memory device
-                    if api.is_flat_memory():
-                        self.log_notice("{}: skipping CMIS state machine for flat memory xcvr".format(lport))
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                        continue
-
-                    # Skip if it's not a CMIS module
-                    type = api.get_module_type_abbreviation()
-                    if (type is None) or (type not in self.CMIS_MODULE_TYPES):
-                        self.log_notice("{}: skipping CMIS state machine for non-CMIS module with type {}".format(lport, type))
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                        continue
-
-                    if api.is_coherent_module():
-                       if 'tx_power' not in self.port_dict[lport]:
-                           self.port_dict[lport]['tx_power'] = self.get_configured_tx_power_from_db(lport)
-                       if 'laser_freq' not in self.port_dict[lport]:
-                           self.port_dict[lport]['laser_freq'] = self.get_configured_laser_freq_from_db(lport)
-                except AttributeError:
-                    # Skip if these essential routines are not available
-                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                    continue
-                except Exception as e:
-                    self.log_error("{}: Exception in xcvr api: {}".format(lport, e))
-                    common.log_exception_traceback()
-                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                    continue
-
-                # CMIS expiration and retries
-                #
-                # A retry should always start over at INSETRTED state, while the
-                # expiration will reset the state to INSETRTED and advance the
-                # retry counter
-                expired = self.port_dict[lport].get('cmis_expired')
-                retries = self.port_dict[lport].get('cmis_retries', 0)
-                host_lanes_mask = self.port_dict[lport].get('host_lanes_mask', 0)
-                appl = self.port_dict[lport].get('appl', 0)
-                # appl can be 0 if this lport is in decommission state machine, which should not be considered as failed case.
-                if state != CMIS_STATE_INSERTED and not self.is_decomm_lead_lport(lport) and (host_lanes_mask <= 0 or appl < 1):
-                    self.log_error("{}: Unexpected value for host_lanes_mask {} or appl {} in "
-                                    "{} state".format(lport, host_lanes_mask, appl, state))
-                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                    continue
-
-                self.log_notice("{}: {}G, lanemask=0x{:x}, CMIS state={}{}, Module state={}, DP state={}, appl {} host_lane_count {} "
-                                "retries={}".format(lport, int(speed/1000), host_lanes_mask, state,
-                                "(decommission" + ("*" if self.is_decomm_lead_lport(lport) else "") + ")"
-                                    if self.is_decomm_pending(lport) else "",
-                                api.get_module_state(), api.get_datapath_state(), appl, host_lane_count, retries))
-                if retries > self.CMIS_MAX_RETRIES:
-                    self.log_error("{}: FAILED".format(lport))
-                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                    continue
-
-                try:
-                    # CMIS state transitions
-                    if state == CMIS_STATE_INSERTED:
-                        self.port_dict[lport]['appl'] = common.get_cmis_application_desired(api, host_lane_count, host_speed)
-                        if self.port_dict[lport]['appl'] is None:
-                            self.log_error("{}: no suitable app for the port appl {} host_lane_count {} "
-                                            "host_speed {}".format(lport, appl, host_lane_count, host_speed))
-                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                            continue
-                        appl = self.port_dict[lport]['appl']
-                        self.log_notice("{}: Setting appl={}".format(lport, appl))
-
-                        self.port_dict[lport]['host_lanes_mask'] = self.get_cmis_host_lanes_mask(api,
-                                                                        appl, host_lane_count, subport)
-                        if self.port_dict[lport]['host_lanes_mask'] <= 0:
-                            self.log_error("{}: Invalid lane mask received - host_lane_count {} subport {} "
-                                            "appl {}!".format(lport, host_lane_count, subport, appl))
-                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                            continue
-                        host_lanes_mask = self.port_dict[lport]['host_lanes_mask']
-                        self.log_notice("{}: Setting host_lanemask=0x{:x}".format(lport, host_lanes_mask))
-
-                        self.port_dict[lport]['media_lane_count'] = int(api.get_media_lane_count(appl))
-                        self.port_dict[lport]['media_lane_assignment_options'] = int(api.get_media_lane_assignment_option(appl))
-                        media_lane_count = self.port_dict[lport]['media_lane_count']
-                        media_lane_assignment_options = self.port_dict[lport]['media_lane_assignment_options']
-                        self.port_dict[lport]['media_lanes_mask'] = self.get_cmis_media_lanes_mask(api,
-                                                                        appl, lport, subport)
-                        if self.port_dict[lport]['media_lanes_mask'] <= 0:
-                            self.log_error("{}: Invalid media lane mask received - media_lane_count {} "
-                                            "media_lane_assignment_options {} subport {}"
-                                            " appl {}!".format(lport, media_lane_count, media_lane_assignment_options, subport, appl))
-                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                            continue
-                        media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
-                        self.log_notice("{}: Setting media_lanemask=0x{:x}".format(lport, media_lanes_mask))
-
-                        if self.is_decommission_required(api, appl):
-                            self.set_decomm_pending(lport)
-
-                        if self.is_decomm_lead_lport(lport):
-                            # Set all the DP lanes AppSel to unused(0) when non default app code needs to be configured
-                            self.port_dict[lport]['appl'] = appl = 0
-                            self.port_dict[lport]['host_lanes_mask'] = host_lanes_mask = self.ALL_LANES_MASK
-                            self.port_dict[lport]['media_lanes_mask'] = self.ALL_LANES_MASK
-                            self.log_notice("{}: DECOMMISSION: setting appl={} and "
-                                            "host_lanes_mask/media_lanes_mask={:#x}".format(lport, appl, self.ALL_LANES_MASK))
-                            # Skip rest of the deinit/pre-init when this is the lead logical port for decommission
-                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
-                            continue
-                        elif self.is_decomm_pending(lport):
-                            if self.is_decomm_failed(lport):
-                                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
-                                decomm_status_str = "failed"
-                            else:
-                                decomm_status_str = "waiting for completion"
-                            self.log_notice("{}: DECOMMISSION: decommission has already started for this physical port, "
-                                            "{}".format(lport, decomm_status_str))
-                            continue
-
-                        if self.port_dict[lport]['host_tx_ready'] != 'true' or \
-                                self.port_dict[lport]['admin_status'] != 'up':
-                           if is_fast_reboot and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
-                               self.log_notice("{} Skip datapath re-init in fast-reboot".format(lport))
-                           else:
-                               self.log_notice("{} Forcing Tx laser OFF".format(lport))
-                               # Force DataPath re-init
-                               api.tx_disable_channel(media_lanes_mask, True)
-                               self.port_dict[lport]['forced_tx_disabled'] = True
-                               txoff_duration = self.get_cmis_dp_tx_turnoff_duration_secs(api)
-                               self.log_notice("{}: Tx turn off duration {} secs".format(lport, txoff_duration))
-                               self.update_cmis_state_expiration_time(lport, txoff_duration)
-                               self.post_port_active_apsel_to_db(api, lport, host_lanes_mask, reset_apsel=True)
-                           self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                           continue
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_PRE_INIT_CHECK)
-                    if state == CMIS_STATE_DP_PRE_INIT_CHECK:
-                        if self.port_dict[lport].get('forced_tx_disabled', False):
-                            # Ensure that Tx is OFF
-                            # Transceiver will remain in DataPathDeactivated state while it is in Low Power Mode (even if Tx is disabled)
-                            # Transceiver will enter DataPathInitialized state if Tx was disabled after CMIS initialization was completed
-                            if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated', 'DataPathInitialized']):
-                                if self.is_timer_expired(expired):
-                                    self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized'".format(lport))
-                                    self.force_cmis_reinit(lport, retries + 1)
-                                continue
-                            self.port_dict[lport]['forced_tx_disabled'] = False
-                            self.log_notice("{}: Tx laser is successfully turned OFF".format(lport))
-
-                        # Configure the target output power if ZR module
-                        if api.is_coherent_module():
-                           tx_power = self.port_dict[lport]['tx_power']
-                           # Prevent configuring same tx power multiple times
-                           if 0 != tx_power and tx_power != api.get_tx_config_power():
-                              if 1 != self.configure_tx_output_power(api, lport, tx_power):
-                                 self.log_error("{} failed to configure Tx power = {}".format(lport, tx_power))
-                              else:
-                                 self.log_notice("{} Successfully configured Tx power = {}".format(lport, tx_power))
-
-                        need_update = self.is_cmis_application_update_required(api, appl, host_lanes_mask)
-
-                        # For ZR module, Datapath needes to be re-initlialized on new channel selection
-                        if api.is_coherent_module():
-                            freq = self.port_dict[lport]['laser_freq']
-                            # If user requested frequency is NOT the same as configured on the module
-                            # force datapath re-initialization
-                            if 0 != freq and freq != api.get_laser_config_freq():
-                                if self.validate_frequency_and_grid(api, lport, freq) == True:
-                                    need_update = True
-                                else:
-                                    # clear setting of invalid frequency config
-                                    self.port_dict[lport]['laser_freq'] = 0
-
-                        if not need_update:
-                            # No application updates
-                            # As part of xcvrd restart, the TRANSCEIVER_INFO table is deleted and
-                            # created with default value of 'N/A' for all the active apsel fields.
-                            # The below (post_port_active_apsel_to_db) will ensure that the
-                            # active apsel fields are updated correctly in the DB since
-                            # the CMIS state remains unchanged during xcvrd restart
-                            self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
-                            self.log_notice("{}: no CMIS application update required...READY".format(lport))
-                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                            continue
-                        self.log_notice("{}: force Datapath reinit".format(lport))
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
-                    elif state == CMIS_STATE_DP_DEINIT:
-                        # D.2.2 Software Deinitialization
-                        api.set_datapath_deinit(host_lanes_mask)
-
-                        # D.1.3 Software Configuration and Initialization
-                        media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
-                        if not api.tx_disable_channel(media_lanes_mask, True):
-                            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {}".format(lport, host_lanes_mask))
-                            self.port_dict[lport]['cmis_retries'] = retries + 1
-                            continue
-
-                        #Sets module to high power mode and doesn't impact datapath if module is already in high power mode
-                        api.set_lpmode(False, wait_state_change = False)
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_AP_CONF)
-                        dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
-                        modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)
-                        self.log_notice("{}: DpDeinit duration {} secs, modulePwrUp duration {} secs".format(lport, dpDeinitDuration, modulePwrUpDuration))
-                        self.update_cmis_state_expiration_time(lport, max(modulePwrUpDuration, dpDeinitDuration))
-
-                    elif state == CMIS_STATE_AP_CONF:
-                        # Explicit control bit to apply custom Host SI settings. 
-                        # It will be set to 1 and applied via set_application if 
-                        # custom SI settings is applicable
-                        ec = 0
-
-                        # TODO: Use fine grained time when the CMIS memory map is available
-                        if not self.check_module_state(api, ['ModuleReady']):
-                            if self.is_timer_expired(expired):
-                                self.log_notice("{}: timeout for 'ModuleReady'".format(lport))
-                                self.force_cmis_reinit(lport, retries + 1)
-                            continue
-
-                        if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated']):
-                            if self.is_timer_expired(expired):
-                                self.log_notice("{}: timeout for 'DataPathDeactivated state'".format(lport))
-                                self.force_cmis_reinit(lport, retries + 1)
-                            continue
-
-                        # Skip rest if it's in decommission state machine
-                        if not self.is_decomm_pending(lport):
-                            if api.is_coherent_module():
-                            # For ZR module, configure the laser frequency when Datapath is in Deactivated state
-                                freq = self.port_dict[lport]['laser_freq']
-                                if 0 != freq:
-                                    if 1 != self.configure_laser_frequency(api, lport, freq):
-                                        self.log_error("{} failed to configure laser frequency {} GHz".format(lport, freq))
-                                    else:
-                                        self.log_notice("{} configured laser frequency {} GHz".format(lport, freq))
-
-                            # Stage custom SI settings
-                            if optics_si_parser.optics_si_present():
-                                optics_si_dict = {}
-                                # Apply module SI settings if applicable
-                                lane_speed = int(speed/1000)//host_lane_count
-                                optics_si_dict = optics_si_parser.fetch_optics_si_setting(pport, lane_speed, sfp)
-
-                                self.log_debug("Read SI parameters for port {} from optics_si_settings.json vendor file:".format(lport))
-                                for key, sub_dict in optics_si_dict.items():
-                                    self.log_debug("{}".format(key))
-                                    for sub_key, value in sub_dict.items():
-                                        self.log_debug("{}: {}".format(sub_key, str(value)))
-
-                                if optics_si_dict:
-                                    self.log_notice("{}: Apply Optics SI found for Vendor: {}  PN: {} lane speed: {}G".
-                                                    format(lport, api.get_manufacturer(), api.get_model(), lane_speed))
-                                    if not api.stage_custom_si_settings(host_lanes_mask, optics_si_dict):
-                                        self.log_notice("{}: unable to stage custom SI settings ".format(lport))
-                                        self.force_cmis_reinit(lport, retries + 1)
-                                        continue
-
-                                    # Set Explicit control bit to apply Custom Host SI settings
-                                    ec = 1
-
-                        # D.1.3 Software Configuration and Initialization
-                        api.set_application(host_lanes_mask, appl, ec)
-                        if not api.scs_apply_datapath_init(host_lanes_mask):
-                            self.log_notice("{}: unable to set application and stage DP init".format(lport))
-                            self.force_cmis_reinit(lport, retries + 1)
-                            continue
-
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_INIT)
-                    elif state == CMIS_STATE_DP_INIT:
-                        if not self.check_config_error(api, host_lanes_mask, ['ConfigSuccess']):
-                            if self.is_timer_expired(expired):
-                                self.log_notice("{}: timeout for 'ConfigSuccess', current ConfigStatus: "
-                                                "{}".format(lport, list(api.get_config_datapath_hostlane_status().values())))
-                                self.force_cmis_reinit(lport, retries + 1)
-                            continue
-
-                        # Clear decommission status and invoke CMIS reinit so that normal CMIS initialization can begin
-                        if self.is_decomm_pending(lport):
-                            self.log_notice("{}: DECOMMISSION: done for physical port {}".format(lport, self.port_dict[lport]['index']))
-                            self.clear_decomm_pending(lport)
-                            self.force_cmis_reinit(lport)
-                            continue
-
-                        if hasattr(api, 'get_cmis_rev'):
-                            # Check datapath init pending on module that supports CMIS 5.x
-                            majorRev = int(api.get_cmis_rev().split('.')[0])
-                            if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes_mask):
-                                self.log_notice("{}: datapath init not pending".format(lport))
-                                self.force_cmis_reinit(lport, retries + 1)
-                                continue
-
-                        # Ensure the Datapath is NOT Activated unless the host Tx siganl is good.
-                        # NOTE: Some CMIS compliant modules may have 'auto-squelch' feature where
-                        # the module won't take datapaths to Activated state if host tries to enable
-                        # the datapaths while there is no good Tx signal from the host-side.
-                        if self.port_dict[lport]['admin_status'] != 'up' or \
-                                self.port_dict[lport]['host_tx_ready'] != 'true':
-                            self.log_notice("{} waiting for host tx ready...".format(lport))
-                            continue
-
-                        # D.1.3 Software Configuration and Initialization
-                        api.set_datapath_init(host_lanes_mask)
-                        dpInitDuration = self.get_cmis_dp_init_duration_secs(api)
-                        self.log_notice("{}: DpInit duration {} secs".format(lport, dpInitDuration))
-                        self.update_cmis_state_expiration_time(lport, dpInitDuration)
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_TXON)
-                    elif state == CMIS_STATE_DP_TXON:
-                        if not self.check_datapath_state(api, host_lanes_mask, ['DataPathInitialized']):
-                            if self.is_timer_expired(expired):
-                                self.log_notice("{}: timeout for 'DataPathInitialized'".format(lport))
-                                self.force_cmis_reinit(lport, retries + 1)
-                            continue
-
-                        # Turn ON the laser
-                        media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
-                        api.tx_disable_channel(media_lanes_mask, False)
-                        self.log_notice("{}: Turning ON tx power".format(lport))
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_ACTIVATE)
-                    elif state == CMIS_STATE_DP_ACTIVATE:
-                        # Use dpInitDuration instead of MaxDurationDPTxTurnOn because
-                        # some modules rely on dpInitDuration to turn on the Tx signal.
-                        # This behavior deviates from the CMIS spec but is honored
-                        # to prevent old modules from breaking with new sonic
-                        if not self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
-                            if self.is_timer_expired(expired):
-                                self.log_notice("{}: timeout for 'DataPathActivated'".format(lport))
-                                self.force_cmis_reinit(lport, retries + 1)
-                            continue
-
-                        self.log_notice("{}: READY".format(lport))
-                        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                        self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
-
-                except Exception as e:
-                    self.log_error("{}: internal errors due to {}".format(lport, e))
-                    common.log_exception_traceback()
-                    self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_FAILED)
+                self.process_single_lport(lport, info)
 
         self.log_notice("Stopped")
 

--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -22,7 +22,8 @@ try:
     from xcvrd.xcvrd_utilities import sfp_status_helper
     from xcvrd.xcvrd_utilities.xcvr_table_helper import *
     from xcvrd.xcvrd_utilities import port_event_helper
-    from xcvrd.xcvrd_utilities import xcvrd_common
+    from xcvrd.xcvrd_utilities import common
+    from xcvrd.xcvrd_utilities.common import CMIS_TERMINAL_STATES
     from xcvrd.dom.utilities.dom_sensor.db_utils import DOMDBUtils
     from xcvrd.dom.utilities.vdm.utils import VDMUtils
     from xcvrd.dom.utilities.vdm.db_utils import VDMDBUtils
@@ -130,8 +131,8 @@ class DomInfoUpdateTask(threading.Thread):
             self.log_warning("Got invalid asic index for {} while checking cmis init status".format(logical_port_name))
             return False
 
-        cmis_state = xcvrd_common.get_cmis_state_from_state_db(logical_port_name, self.xcvr_table_helper.get_status_sw_tbl(asic_index))
-        if cmis_state not in xcvrd.CMIS_TERMINAL_STATES:
+        cmis_state = common.get_cmis_state_from_state_db(logical_port_name, self.xcvr_table_helper.get_status_sw_tbl(asic_index))
+        if cmis_state not in CMIS_TERMINAL_STATES:
             return True
         else:
             return False

--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -22,7 +22,7 @@ try:
     from xcvrd.xcvrd_utilities import sfp_status_helper
     from xcvrd.xcvrd_utilities.xcvr_table_helper import *
     from xcvrd.xcvrd_utilities import port_event_helper
-    from xcvrd.xcvrd_utilities import common
+    from xcvrd.xcvrd_utilities import xcvrd_common
     from xcvrd.dom.utilities.dom_sensor.db_utils import DOMDBUtils
     from xcvrd.dom.utilities.vdm.utils import VDMUtils
     from xcvrd.dom.utilities.vdm.db_utils import VDMDBUtils
@@ -130,8 +130,8 @@ class DomInfoUpdateTask(threading.Thread):
             self.log_warning("Got invalid asic index for {} while checking cmis init status".format(logical_port_name))
             return False
 
-        cmis_state = common.get_cmis_state_from_state_db(logical_port_name, self.xcvr_table_helper.get_status_sw_tbl(asic_index))
-        if cmis_state not in common.CMIS_TERMINAL_STATES:
+        cmis_state = xcvrd_common.get_cmis_state_from_state_db(logical_port_name, self.xcvr_table_helper.get_status_sw_tbl(asic_index))
+        if cmis_state not in xcvrd.CMIS_TERMINAL_STATES:
             return True
         else:
             return False
@@ -143,11 +143,11 @@ class DomInfoUpdateTask(threading.Thread):
     # Update port sfp firmware info in db
     def post_port_sfp_firmware_info_to_db(self, logical_port_name, port_mapping, table,
                                 stop_event=threading.Event(), firmware_info_cache=None):
-        for physical_port, physical_port_name in common.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+        for physical_port, physical_port_name in xcvrd_common.get_physical_port_name_dict(logical_port_name, port_mapping).items():
             if stop_event.is_set():
                 break
 
-            if not common._wrapper_get_presence(physical_port):
+            if not xcvrd_common._wrapper_get_presence(physical_port):
                 continue
 
             try:
@@ -155,7 +155,7 @@ class DomInfoUpdateTask(threading.Thread):
                     # If cache is enabled and firmware information is in cache, just read from cache, no need read from EEPROM
                     transceiver_firmware_info_dict = firmware_info_cache[physical_port]
                 else:
-                    transceiver_firmware_info_dict = common._wrapper_get_transceiver_firmware_info(physical_port)
+                    transceiver_firmware_info_dict = xcvrd_common._wrapper_get_transceiver_firmware_info(physical_port)
                     if firmware_info_cache is not None:
                         # If cache is enabled, put firmware information to cache
                         firmware_info_cache[physical_port] = transceiver_firmware_info_dict
@@ -177,21 +177,21 @@ class DomInfoUpdateTask(threading.Thread):
 
     # Update port pm info in db
     def post_port_pm_info_to_db(self, logical_port_name, port_mapping, table, stop_event=threading.Event(), pm_info_cache=None):
-        for physical_port, physical_port_name in common.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+        for physical_port, physical_port_name in xcvrd_common.get_physical_port_name_dict(logical_port_name, port_mapping).items():
             if stop_event.is_set():
                 break
 
-            if not common._wrapper_get_presence(physical_port):
+            if not xcvrd_common._wrapper_get_presence(physical_port):
                 continue
 
-            if common._wrapper_is_flat_memory(physical_port) == True:
+            if xcvrd_common._wrapper_is_flat_memory(physical_port) == True:
                 continue
 
             if pm_info_cache is not None and physical_port in pm_info_cache:
                 # If cache is enabled and pm info is in cache, just read from cache, no need read from EEPROM
                 pm_info_dict = pm_info_cache[physical_port]
             else:
-                pm_info_dict = common._wrapper_get_transceiver_pm(physical_port)
+                pm_info_dict = xcvrd_common._wrapper_get_transceiver_pm(physical_port)
                 if pm_info_cache is not None:
                     # If cache is enabled, put dom information to cache
                     pm_info_cache[physical_port] = pm_info_dict
@@ -269,7 +269,7 @@ class DomInfoUpdateTask(threading.Thread):
                     continue
 
                 if not sfp_status_helper.detect_port_in_error_status(logical_port_name, self.xcvr_table_helper.get_status_sw_tbl(asic_index)):
-                    if not common._wrapper_get_presence(physical_port):
+                    if not xcvrd_common._wrapper_get_presence(physical_port):
                         continue
 
                     try:
@@ -346,7 +346,7 @@ class DomInfoUpdateTask(threading.Thread):
             self.task_worker()
         except Exception as e:
             self.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().getName(), repr(e)))
-            common.log_exception_traceback()
+            xcvrd_common.log_exception_traceback()
             self.exc = e
             self.main_thread_stop_event.set()
 
@@ -441,7 +441,7 @@ class DomInfoUpdateTask(threading.Thread):
         # To avoid race condition, remove the entry TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table.
         # This thread only updates TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table,
         # so we don't have to remove entries from TRANSCEIVER_INFO, TRANSCEIVER_DOM_THRESHOLD and VDM threshold value tables.
-        common.del_port_sfp_dom_info_from_db(port_change_event.port_name,
+        xcvrd_common.del_port_sfp_dom_info_from_db(port_change_event.port_name,
                                       self.port_mapping,
                                       [self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),
                                       self.xcvr_table_helper.get_dom_flag_tbl(port_change_event.asic_id),

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -35,7 +35,7 @@ try:
     from .xcvrd_utilities.port_event_helper import PortChangeObserver
     from .xcvrd_utilities import media_settings_parser
     from .xcvrd_utilities import optics_si_parser
-    from .xcvrd_utilities import common
+    from .xcvrd_utilities import xcvrd_common
     from xcvrd.dom.utilities.dom_sensor.db_utils import DOMDBUtils
     from xcvrd.dom.utilities.vdm.db_utils import VDMDBUtils
     
@@ -119,7 +119,7 @@ def _wrapper_get_transceiver_info(physical_port):
             pass
         except Exception as e:
             helper_logger.log_error("Failed to get transceiver info for physical port {}. Exception: {}".format(physical_port, e))
-            common.log_exception_traceback()
+            xcvrd_common.log_exception_traceback()
             return None
     return platform_sfputil.get_transceiver_info_dict(physical_port)
 
@@ -192,11 +192,11 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
         if stop_event.is_set():
             break
 
-        if not common._wrapper_get_presence(physical_port):
+        if not xcvrd_common._wrapper_get_presence(physical_port):
             helper_logger.log_notice("Transceiver not present in port {}".format(logical_port_name))
             continue
 
-        port_name = common.get_physical_port_name(logical_port_name, ganged_member_num, ganged_port)
+        port_name = xcvrd_common.get_physical_port_name(logical_port_name, ganged_member_num, ganged_port)
         ganged_member_num += 1
 
         try:
@@ -253,65 +253,7 @@ def waiting_time_compensation_with_sleep(time_start, time_to_wait):
 
 # Delete port from SFP status table
 
-# Thread wrapper class to update sfp state info periodically
-
-
-class SfpStateUpdateTask(threading.Thread):
-    RETRY_EEPROM_READING_INTERVAL = 60
-    def __init__(self, namespaces, port_mapping, sfp_obj_dict, main_thread_stop_event, sfp_error_event):
-        threading.Thread.__init__(self)
-        self.name = "SfpStateUpdateTask"
-        self.exc = None
-        self.task_stopping_event = threading.Event()
-        self.main_thread_stop_event = main_thread_stop_event
-        self.sfp_error_event = sfp_error_event
-        self.port_mapping = copy.deepcopy(port_mapping)
-        # A set to hold those logical port name who fail to read EEPROM
-        self.retry_eeprom_set = set()
-        # To avoid retry EEPROM read too fast, record the last EEPROM read timestamp in this member
-        self.last_retry_eeprom_time = 0
-        # A dict to hold SFP error event, for SFP insert/remove event, it is not necessary to cache them
-        # because _wrapper_get_presence returns the SFP presence status
-        self.sfp_error_dict = {}
-        self.sfp_insert_events = {}
-        self.namespaces = namespaces
-        self.sfp_obj_dict = sfp_obj_dict
-        self.logger = syslogger.SysLogger(SYSLOG_IDENTIFIER_SFPSTATEUPDATETASK, enable_runtime_config=True)
-        self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
-        self.dom_db_utils = DOMDBUtils(sfp_obj_dict, self.port_mapping, self.xcvr_table_helper, self.task_stopping_event, self.logger)
-        self.vdm_db_utils = VDMDBUtils(sfp_obj_dict, self.port_mapping, self.xcvr_table_helper, self.task_stopping_event, self.logger)
-
-    def _mapping_event_from_change_event(self, status, port_dict):
-        """
-        mapping from what get_transceiver_change_event returns to event defined in the state machine
-        the logic is pretty straightforword
-        """
-        if status:
-            if bool(port_dict):
-                event = NORMAL_EVENT
-            else:
-                event = SYSTEM_BECOME_READY
-                # here, a simple timeout event whose port_dict is empty is mapped
-                # into a SYSTEM_BECOME_READY event so that it can be handled
-                port_dict[EVENT_ON_ALL_SFP] = SYSTEM_BECOME_READY
-        else:
-            if EVENT_ON_ALL_SFP in port_dict.keys():
-                event = port_dict[EVENT_ON_ALL_SFP]
-            else:
-                # this should not happen. just for protection
-                event = SYSTEM_FAIL
-                port_dict[EVENT_ON_ALL_SFP] = SYSTEM_FAIL
-
-        helper_logger.log_debug("mapping from {} {} to {}".format(status, port_dict, event))
-        return event
-
-    # Update port sfp info and dom threshold in db during xcvrd bootup
-    def _post_port_sfp_info_and_dom_thr_to_db_once(self, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
-        # Connect to STATE_DB and create transceiver dom/sfp info tables
-        transceiver_dict = {}
-        retry_eeprom_set = set()
-
-        is_warm_start = common.is_syncd_warm_restore_complete()
+        is_warm_start = xcvrd_common.is_warm_reboot_enabled()
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
         for logical_port_name in logical_port_list:
@@ -360,16 +302,16 @@ class SfpStateUpdateTask(threading.Thread):
             physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
             if physical_port_list is None:
                 helper_logger.log_error("No physical ports found for logical port '{}' during sfp status table init".format(logical_port_name))
-                common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
+                xcvrd_common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
 
             for physical_port in physical_port_list:
                 if stop_event.is_set():
                     break
 
-                if not common._wrapper_get_presence(physical_port):
-                    common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
+                if not xcvrd_common._wrapper_get_presence(physical_port):
+                    xcvrd_common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
                 else:
-                    common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
+                    xcvrd_common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
 
     def init(self):
         port_mapping_data = port_event_helper.get_port_mapping(self.namespaces)
@@ -542,7 +484,7 @@ class SfpStateUpdateTask(threading.Thread):
                             if value == sfp_status_helper.SFP_STATUS_INSERTED:
                                 helper_logger.log_notice("{}: Got SFP inserted event".format(logical_port))
                                 # A plugin event will clear the error state.
-                                common.update_port_transceiver_status_table_sw(
+                                xcvrd_common.update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
                                 helper_logger.log_notice("{}: received plug in and update port sfp status table.".format(logical_port))
                                 rc = post_port_sfp_info_to_db(logical_port, self.port_mapping, self.xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict)
@@ -571,10 +513,10 @@ class SfpStateUpdateTask(threading.Thread):
                                 helper_logger.log_notice("{}: Got SFP removed event".format(logical_port))
                                 state_port_table = self.xcvr_table_helper.get_state_port_tbl(asic_index)
                                 state_port_table.set(logical_port, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY, NPU_SI_SETTINGS_DEFAULT_VALUE)])
-                                common.update_port_transceiver_status_table_sw(
+                                xcvrd_common.update_port_transceiver_status_table_sw(
                                     logical_port, self.xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
                                 helper_logger.log_notice("{}: received plug out and update port sfp status table.".format(logical_port))
-                                common.del_port_sfp_dom_info_from_db(logical_port, self.port_mapping, [
+                                xcvrd_common.del_port_sfp_dom_info_from_db(logical_port, self.port_mapping, [
                                                               self.xcvr_table_helper.get_intf_tbl(asic_index),
                                                               self.xcvr_table_helper.get_dom_tbl(asic_index),
                                                               self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
@@ -612,12 +554,12 @@ class SfpStateUpdateTask(threading.Thread):
 
                                     # Add error info to database
                                     # Any existing error will be replaced by the new one.
-                                    common.update_port_transceiver_status_table_sw(logical_port, self.xcvr_table_helper.get_status_sw_tbl(asic_index), value, '|'.join(error_descriptions))
+                                    xcvrd_common.update_port_transceiver_status_table_sw(logical_port, self.xcvr_table_helper.get_status_sw_tbl(asic_index), value, '|'.join(error_descriptions))
                                     helper_logger.log_notice("{}: Receive error update port sfp status table.".format(logical_port))
                                     # In this case EEPROM is not accessible. The DOM info will be removed since it can be out-of-date.
                                     # The interface info remains in the DB since it is static.
                                     if sfp_status_helper.is_error_block_eeprom_reading(error_bits):
-                                        common.del_port_sfp_dom_info_from_db(logical_port,
+                                        xcvrd_common.del_port_sfp_dom_info_from_db(logical_port,
                                                                       self.port_mapping, [
                                                                       self.xcvr_table_helper.get_dom_tbl(asic_index),
                                                                       self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
@@ -688,7 +630,7 @@ class SfpStateUpdateTask(threading.Thread):
             self.task_worker(self.task_stopping_event, self.sfp_error_event)
         except Exception as e:
             helper_logger.log_error("Exception occured at {} thread due to {}".format(threading.current_thread().name, repr(e)))
-            common.log_exception_traceback()
+            xcvrd_common.log_exception_traceback()
             self.exc = e
             self.main_thread_stop_event.set()
 
@@ -725,7 +667,7 @@ class SfpStateUpdateTask(threading.Thread):
         # To avoid race condition, remove the entry TRANSCEIVER_DOM_INFO, TRANSCEIVER_STATUS_INFO and TRANSCEIVER_INFO table.
         # The operation to remove entry from TRANSCEIVER_DOM_INFO is duplicate with DomInfoUpdateTask.on_remove_logical_port,
         # but it is necessary because TRANSCEIVER_DOM_INFO is also updated in this thread when a new SFP is inserted.
-        common.del_port_sfp_dom_info_from_db(port_change_event.port_name,
+        xcvrd_common.del_port_sfp_dom_info_from_db(port_change_event.port_name,
                                       self.port_mapping, [
                                       self.xcvr_table_helper.get_intf_tbl(port_change_event.asic_id),
                                       self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),
@@ -797,7 +739,7 @@ class SfpStateUpdateTask(threading.Thread):
                 read_eeprom = False
 
         # SFP information not in DB
-        if common._wrapper_get_presence(port_change_event.port_index) and read_eeprom:
+        if xcvrd_common._wrapper_get_presence(port_change_event.port_index) and read_eeprom:
             transceiver_dict = {}
             status = sfp_status_helper.SFP_STATUS_INSERTED if not status else status
             rc = post_port_sfp_info_to_db(port_change_event.port_name, self.port_mapping, int_tbl, transceiver_dict)
@@ -810,7 +752,7 @@ class SfpStateUpdateTask(threading.Thread):
                 media_settings_parser.notify_media_setting(port_change_event.port_name, transceiver_dict, self.xcvr_table_helper, self.port_mapping)
         else:
             status = sfp_status_helper.SFP_STATUS_REMOVED if not status else status
-        common.update_port_transceiver_status_table_sw(port_change_event.port_name, status_sw_tbl, status, error_description)
+        xcvrd_common.update_port_transceiver_status_table_sw(port_change_event.port_name, status_sw_tbl, status, error_description)
 
     def retry_eeprom_reading(self):
         """Retry EEPROM reading, if retry succeed, remove the logical port from the retry set
@@ -989,9 +931,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                     continue
                 pport = pport_list[0]
 
-                if not common._wrapper_get_presence(pport):
+                if not xcvrd_common._wrapper_get_presence(pport):
                     self.log_notice(f"Remove stale transceiver info: Transceiver is absent for lport {lport}")
-                    common.del_port_sfp_dom_info_from_db(lport, port_mapping_data, [intf_tbl])
+                    xcvrd_common.del_port_sfp_dom_info_from_db(lport, port_mapping_data, [intf_tbl])
 
     # Initialize daemon
     def init(self):
@@ -1017,7 +959,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 sys.exit(SFPUTIL_LOAD_ERROR)
 
         # Initialize shared utilities with platform objects
-        common.init_globals(platform_chassis, platform_sfputil)
+        xcvrd_common.init_globals(platform_chassis, platform_sfputil, helper_logger)
 
         if multi_asic.is_multi_asic():
             # Load the namespace details first from the database_global.json file.
@@ -1029,7 +971,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Initialize xcvr table helper
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
 
-        if common.is_fast_reboot_enabled():
+        if xcvrd_common.is_fast_reboot_enabled():
             self.log_info("Skip loading media_settings.json and optics_si_settings.json in case of fast-reboot")
         else:
             media_settings_parser.load_media_settings()
@@ -1058,7 +1000,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def deinit(self):
         self.log_info("Start daemon deinit...")
 
-        is_warm_fast_reboot = common.is_syncd_warm_restore_complete() or common.is_fast_reboot_enabled()
+        is_warm_fast_reboot = xcvrd_common.is_warm_reboot_enabled() or xcvrd_common.is_fast_reboot_enabled()
 
         # Delete all the information from DB and then exit
         port_mapping_data = port_event_helper.get_port_mapping(self.namespaces)
@@ -1074,7 +1016,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             # due to TRANSCEIVER_INFO table deletion during xcvrd shutdown/crash
             intf_tbl = None
 
-            common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data, [
+            xcvrd_common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data, [
                                           intf_tbl,
                                           self.xcvr_table_helper.get_dom_tbl(asic_index),
                                           self.xcvr_table_helper.get_dom_flag_tbl(asic_index),
@@ -1097,7 +1039,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                                           ])
 
             if not is_warm_fast_reboot:
-                common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data, [
+                xcvrd_common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data, [
                                           self.xcvr_table_helper.get_status_tbl(asic_index),
                                           self.xcvr_table_helper.get_status_sw_tbl(asic_index),
                                           ])

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -12,7 +12,7 @@ from sonic_py_common import device_info, syslogger
 from swsscommon import swsscommon
 from xcvrd import xcvrd
 from .xcvr_table_helper import *
-from . import common
+from . import xcvrd_common
 
 g_dict = {}
 
@@ -80,9 +80,9 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
     api = sfp.get_xcvr_api()
     
     lane_speed_key = None
-    if common.is_cmis_api(api):
+    if xcvrd_common.is_cmis_api(api):
         appl_adv_dict = api.get_application_advertisement()
-        app_id = common.get_cmis_application_desired(api, lane_count, port_speed)
+        app_id = xcvrd_common.get_cmis_application_desired(api, lane_count, port_speed)
         if app_id and app_id in appl_adv_dict:
             host_electrical_interface_id = appl_adv_dict[app_id].get('host_electrical_interface_id')
             if host_electrical_interface_id:
@@ -116,7 +116,7 @@ def get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_cou
     try:
         sfp = xcvrd.platform_chassis.get_sfp(physical_port)
         api = sfp.get_xcvr_api()
-        if common.is_cmis_api(api):
+        if xcvrd_common.is_cmis_api(api):
             media_compliance_code = media_compliance_dict_str
         else:
             media_compliance_dict = ast.literal_eval(media_compliance_dict_str)
@@ -137,7 +137,7 @@ def get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_cou
         media_key += '-' + media_compliance_code
         sfp = xcvrd.platform_chassis.get_sfp(physical_port)
         api = sfp.get_xcvr_api()
-        if common.is_cmis_api(api):
+        if xcvrd_common.is_cmis_api(api):
             if media_compliance_code == "passive_copper_media_interface":
                 if media_len != 0:
                     media_key += '-' + str(media_len) + 'M'
@@ -252,7 +252,7 @@ def get_media_settings_value(physical_port, key):
                 port_list = keys.split(COMMA_SEPARATOR)
                 for port in port_list:
                     if RANGE_SEPARATOR in port:
-                        if common.check_port_in_range(port, physical_port):
+                        if xcvrd_common.check_port_in_range(port, physical_port):
                             media_dict = g_dict[GLOBAL_MEDIA_SETTINGS_KEY][keys]
                             break
                     elif str(physical_port) == port:
@@ -260,7 +260,7 @@ def get_media_settings_value(physical_port, key):
                         break
 
             elif RANGE_SEPARATOR in keys:
-                if common.check_port_in_range(keys, physical_port):
+                if xcvrd_common.check_port_in_range(keys, physical_port):
                     media_dict = g_dict[GLOBAL_MEDIA_SETTINGS_KEY][keys]
 
             # If there is a match in the global profile for a media type,
@@ -348,14 +348,14 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         ganged_port = True
 
     for physical_port in physical_port_list:
-        if not common._wrapper_get_presence(physical_port):
+        if not xcvrd_common._wrapper_get_presence(physical_port):
             helper_logger.log_info("Media {} presence not detected during notify".format(physical_port))
             continue
         if physical_port not in transceiver_dict:
             helper_logger.log_error("Media {} eeprom not populated in transceiver dict".format(physical_port))
             continue
 
-        port_name = common.get_physical_port_name(logical_port_name,
+        port_name = xcvrd_common.get_physical_port_name(logical_port_name,
                                            ganged_member_num, ganged_port)
         
         ganged_member_num += 1

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -4,7 +4,7 @@ import re
 
 from sonic_py_common import device_info, syslogger
 from xcvrd import xcvrd
-from . import common
+from . import xcvrd_common
 
 g_optics_si_dict = {}
 
@@ -65,7 +65,7 @@ def _get_global_media_settings(physical_port, lane_speed, key, vendor_name_str):
                 port_list = keys.split(COMMA_SEPARATOR)
                 for port in port_list:
                     if RANGE_SEPARATOR in port:
-                        if common.check_port_in_range(port, physical_port):
+                        if xcvrd_common.check_port_in_range(port, physical_port):
                             optics_si_dict = g_optics_si_dict[GLOBAL_MEDIA_SETTINGS_KEY][keys]
                             break
                     elif str(physical_port) == port:
@@ -73,7 +73,7 @@ def _get_global_media_settings(physical_port, lane_speed, key, vendor_name_str):
                         break
 
             elif RANGE_SEPARATOR in keys:
-                if common.check_port_in_range(keys, physical_port):
+                if xcvrd_common.check_port_in_range(keys, physical_port):
                     optics_si_dict = g_optics_si_dict[GLOBAL_MEDIA_SETTINGS_KEY][keys]
 
             if SPEED_KEY in optics_si_dict:
@@ -182,7 +182,7 @@ def fetch_optics_si_setting(physical_port, lane_speed, sfp):
 
     optics_si = {}
 
-    if not common._wrapper_get_presence(physical_port):
+    if not xcvrd_common._wrapper_get_presence(physical_port):
         helper_logger.log_info("Module {} presence not detected during notify".format(physical_port))
         return optics_si
     vendor_key, vendor_name = get_module_vendor_key(physical_port, sfp)

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_common.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvrd_common.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+"""
+    xcvrd_common
+    Common utilities for xcvrd daemon components
+"""
+
+try:
+    import sys
+    import subprocess
+    import traceback
+    from swsscommon import swsscommon
+    from sonic_py_common import syslogger
+    from . import sfp_status_helper
+    from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CmisApi
+
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+SYSLOG_IDENTIFIER = "xcvrd_common"
+
+# Global variables that will be injected from the parent module
+platform_chassis = None
+platform_sfputil = None
+helper_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER, enable_runtime_config=True)
+
+def init_globals(chassis, sfputil, logger):
+    """Initialize global variables with injected dependencies"""
+    global platform_chassis, platform_sfputil, helper_logger
+    platform_chassis = chassis
+    platform_sfputil = sfputil
+    helper_logger = logger
+
+def log_exception_traceback():
+    """Log exception traceback using the helper logger"""
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
+    for tb_line in msg:
+        for tb_line_split in tb_line.splitlines():
+            helper_logger.log_error(tb_line_split)
+
+def update_port_transceiver_status_table_sw(logical_port_name, status_sw_tbl, status, error_descriptions='N/A'):
+    """Update port SFP status table for SW fields on receiving SFP change event"""
+    fvs = swsscommon.FieldValuePairs([('status', status), ('error', error_descriptions)])
+    status_sw_tbl.set(logical_port_name, fvs)
+
+def _wrapper_get_presence(physical_port):
+    """Wrapper function to get SFP presence status"""
+    if platform_chassis is not None:
+        try:
+            return platform_chassis.get_sfp(physical_port).get_presence()
+        except NotImplementedError:
+            pass
+    if platform_sfputil is not None:
+        try:
+            return platform_sfputil.get_presence(physical_port)
+        except NotImplementedError:
+            pass
+    return False
+
+def is_fast_reboot_enabled():
+    """Check if fast reboot is enabled"""
+    fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
+    return "true" in fastboot_enabled
+
+def is_warm_reboot_enabled():
+    """Check if warm reboot is enabled"""
+    warmstart = swsscommon.WarmStart()
+    warmstart.initialize("xcvrd", "pmon")
+    warmstart.checkWarmStart("xcvrd", "pmon", False)
+    is_warm_start = warmstart.isWarmStart()
+    return is_warm_start
+
+#
+# CMIS Helper Functions ========================================================
+#
+
+def is_cmis_api(api):
+    """Check if the API is a CMIS API"""
+    return isinstance(api, CmisApi)
+
+def get_interface_speed(ifname):
+    """
+    Get the port speed from the host interface name
+
+    Args:
+        ifname: String, interface name
+
+    Returns:
+        Integer, the port speed if success otherwise 0
+    """
+    # see HOST_ELECTRICAL_INTERFACE of sff8024.py
+    speed = 0
+    if '800G' in ifname:
+        speed = 800000
+    elif '400G' in ifname:
+        speed = 400000
+    elif '200G' in ifname:
+        speed = 200000
+    elif '100G' in ifname or 'CAUI-4' in ifname:
+        speed = 100000
+    elif '50G' in ifname or 'LAUI-2' in ifname:
+        speed = 50000
+    elif '40G' in ifname or 'XLAUI' in ifname or 'XLPPI' in ifname:
+        speed = 40000
+    elif '25G' in ifname:
+        speed = 25000
+    elif '10G' in ifname or 'SFI' in ifname or 'XFI' in ifname:
+        speed = 10000
+    elif '1000BASE' in ifname:
+        speed = 1000
+
+    return speed
+
+def get_cmis_application_desired(api, host_lane_count, speed):
+    """
+    Get the CMIS application code that matches the specified host side configurations
+
+    Args:
+        api:
+            XcvrApi object
+        host_lane_count:
+            Number of lanes on the host side
+        speed:
+            Integer, the port speed of the host interface
+
+    Returns:
+        Integer, the transceiver-specific application code
+    """
+
+    if speed == 0 or host_lane_count == 0:
+        return None
+
+    if not is_cmis_api(api):
+        return None
+
+    appl_dict = api.get_application_advertisement()
+    for index, app_info in appl_dict.items():
+        if (app_info.get('host_lane_count') == host_lane_count and
+        get_interface_speed(app_info.get('host_electrical_interface_id')) == speed):
+            return (index & 0xf)
+
+    # Note: helper_logger is not available here, so we don't log
+    return None
+
+def get_cmis_state_from_state_db(lport, status_sw_tbl):
+    """Get CMIS state from STATE_DB for a given logical port"""
+    found, cmis_state = status_sw_tbl.hget(lport, 'cmis_state')
+    return cmis_state if found else 'UNKNOWN'
+
+#
+# Physical Port Name Functions =================================================
+#
+
+def get_physical_port_name(logical_port, physical_port, ganged):
+    """Get physical port name based on logical port and ganged status"""
+    if ganged:
+        return logical_port + ":{} (ganged)".format(physical_port)
+    else:
+        return logical_port
+
+def get_physical_port_name_dict(logical_port_name, port_mapping):
+    """Get physical port name dict (port_idx to port_name)"""
+    ganged_port = False
+    ganged_member_num = 1
+
+    physical_port_list = port_mapping.logical_port_name_to_physical_port_list(logical_port_name)
+    if physical_port_list is None:
+        helper_logger.log_error("No physical ports found for logical port '{}'".format(logical_port_name))
+        return {}
+
+    if len(physical_port_list) > 1:
+        ganged_port = True
+
+    port_name_dict = {}
+    for physical_port in physical_port_list:
+        port_name = get_physical_port_name(logical_port_name, ganged_member_num, ganged_port)
+        ganged_member_num += 1
+        port_name_dict[physical_port] = port_name
+
+    return port_name_dict
+
+#
+# Wrapper Functions for Platform API ==========================================
+#
+
+def _wrapper_is_flat_memory(physical_port):
+    """Check if transceiver is flat memory"""
+    if platform_chassis is not None:
+        try:
+            sfp = platform_chassis.get_sfp(physical_port)
+            api = sfp.get_xcvr_api()
+            if not api:
+                return True
+            return api.is_flat_memory()
+        except NotImplementedError:
+            pass
+    return None
+
+def _wrapper_get_transceiver_firmware_info(physical_port):
+    """Get transceiver firmware info"""
+    if platform_chassis is not None:
+        try:
+            return platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
+        except NotImplementedError:
+            pass
+    return {}
+
+def _wrapper_get_transceiver_pm(physical_port):
+    """Get transceiver PM info"""
+    if platform_chassis is not None:
+        try:
+            return platform_chassis.get_sfp(physical_port).get_transceiver_pm()
+        except NotImplementedError:
+            pass
+    return {}
+
+#
+# Database Helper Functions ===================================================
+#
+
+def del_port_sfp_dom_info_from_db(logical_port_name, port_mapping, tbl_to_del_list):
+    """Delete port dom/sfp info from db"""
+    physical_port_names = get_physical_port_name_dict(logical_port_name, port_mapping).values()
+    for physical_port_name in physical_port_names:
+        try:
+            for tbl in filter(None, tbl_to_del_list):
+                tbl._del(physical_port_name)
+        except NotImplementedError:
+            helper_logger.log_error("This functionality is currently not implemented for this platform")
+            sys.exit(2)  # NOT_IMPLEMENTED_ERROR
+
+#
+# Utility Functions ===========================================================
+#
+
+def check_port_in_range(range_str, physical_port):
+    """Check if physical port is in the specified range"""
+    RANGE_SEPARATOR = '-'
+    
+    range_list = range_str.split(RANGE_SEPARATOR)
+    start_num = int(range_list[0].strip())
+    end_num = int(range_list[1].strip())
+    if start_num <= physical_port <= end_num:
+        return True
+    return False


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Seperate task_worker into two functions:

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
xcvrd has gotten to 4000 lines long. To make things easier, we'd like to refactor it. This is the first PR in a series that aims to do the following:

| Task | PR |
|------|-------------|
| 1) Move functions used across multiple files in xcvrd to utils/common.py | https://github.com/sonic-net/sonic-platform-daemons/pull/654 |
| 2) Move CmisManagerTask into cmis/cmis_manager_task.py |  https://github.com/bobby-nexthop/sonic-platform-daemons/pull/1 |
| 3) Split task_worker into process_lport and process_cmis_state |  This PR |
| 4 Rename xcvrd/xcvrd_utilities to xcvrd/utils ||
| 5 Refactor CmisManagerTask to handle state processing in individual functions rather than a large task_worker while loop ||

The new flow will go from calling `task_worker()` to
<img width="1000" height="333" alt="CMIS Refactor Flow" src="https://github.com/user-attachments/assets/e9dfa22c-bc40-41d4-b4cb-9a39f02ff440" />





#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Unit tests all pass

#### Additional Information (Optional)
