### PR TITLE
Xcvrd Refactor 7/N: Add handle_cmis_dp_deinit_state function

### DIFF
--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -771,7 +771,6 @@ class CmisManagerTask(threading.Thread):
         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_PRE_INIT_CHECK)
 
     def handle_cmis_dp_pre_init_check_state(self, lport):
-        # Retrieve needed variables from port_dict
         port_info = self.port_dict[lport]
         api = port_info.get('api')
         appl = port_info.get('appl', 0)
@@ -829,6 +828,30 @@ class CmisManagerTask(threading.Thread):
         self.log_notice("{}: force Datapath reinit".format(lport))
         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
 
+    def handle_cmis_dp_deinit_state(self, lport):
+        port_info = self.port_dict[lport]
+        api = port_info.get('api')
+        host_lanes_mask = port_info.get('host_lanes_mask', 0)
+        retries = port_info.get('cmis_retries', 0)
+
+        # D.2.2 Software Deinitialization
+        api.set_datapath_deinit(host_lanes_mask)
+
+        # D.1.3 Software Configuration and Initialization
+        media_lanes_mask = port_info['media_lanes_mask']
+        if not api.tx_disable_channel(media_lanes_mask, True):
+            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {}".format(lport, host_lanes_mask))
+            port_info['cmis_retries'] = retries + 1
+            return
+
+        #Sets module to high power mode and doesn't impact datapath if module is already in high power mode
+        api.set_lpmode(False, wait_state_change = False)
+        self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_AP_CONF)
+        dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
+        modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)
+        self.log_notice("{}: DpDeinit duration {} secs, modulePwrUp duration {} secs".format(lport, dpDeinitDuration, modulePwrUpDuration))
+        self.update_cmis_state_expiration_time(lport, max(modulePwrUpDuration, dpDeinitDuration))
+
     def process_cmis_state_machine(self, lport):
         port_info = self.port_dict[lport]
         state = common.get_cmis_state_from_state_db(lport, self.xcvr_table_helper.get_status_sw_tbl(self.get_asic_id(lport)))
@@ -872,24 +895,7 @@ class CmisManagerTask(threading.Thread):
             if state == CMIS_STATE_DP_PRE_INIT_CHECK:
                 self.handle_cmis_dp_pre_init_check_state(lport)
             elif state == CMIS_STATE_DP_DEINIT:
-                # D.2.2 Software Deinitialization
-                api.set_datapath_deinit(host_lanes_mask)
-
-                # D.1.3 Software Configuration and Initialization
-                media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
-                if not api.tx_disable_channel(media_lanes_mask, True):
-                    self.log_notice("{}: unable to turn off tx power with host_lanes_mask {}".format(lport, host_lanes_mask))
-                    self.port_dict[lport]['cmis_retries'] = retries + 1
-                    return
-
-                #Sets module to high power mode and doesn't impact datapath if module is already in high power mode
-                api.set_lpmode(False, wait_state_change = False)
-                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_AP_CONF)
-                dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
-                modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)
-                self.log_notice("{}: DpDeinit duration {} secs, modulePwrUp duration {} secs".format(lport, dpDeinitDuration, modulePwrUpDuration))
-                self.update_cmis_state_expiration_time(lport, max(modulePwrUpDuration, dpDeinitDuration))
-
+                self.handle_cmis_dp_deinit_state(lport)
             elif state == CMIS_STATE_AP_CONF:
                 # Explicit control bit to apply custom Host SI settings. 
                 # It will be set to 1 and applied via set_application if 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Move DP_DEINIT handling into its own handle_cmis_dp_deinit_state function

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
xcvrd has gotten to 4000 lines long. To make things easier, we'd like to refactor it. This PR is in a series that aims to do the following:

| Task | PR |
|------|-------------|
| 1) Move functions used across multiple files in xcvrd to utils/common.py | https://github.com/sonic-net/sonic-platform-daemons/pull/654 |
| 2) Move CmisManagerTask into cmis/cmis_manager_task.py |  https://github.com/bobby-nexthop/sonic-platform-daemons/pull/1 |
| 3) Split task_worker into process_lport and process_cmis_state |  https://github.com/bobby-nexthop/sonic-platform-daemons/pull/2 |
| 4) Rename xcvrd/xcvrd_utilities to xcvrd/utils | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/3 |
| 5) Add handle_cmis_inserted_state function | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/4 |
| 6) Add handle_cmis_dp_pre_init_check_state function | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/5 |
| 7) Add handle_cmis_dpdeinit_state function | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/6 |
| 8) Add handle_cmis_ap_conf_state function | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/7 |
| 9) Add handle_cmis_dp_init_state | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/8 |
| 10) Add handle_cmis_txon_state | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/9 |
| 11) Add handle_cmis_activate_state | https://github.com/bobby-nexthop/sonic-platform-daemons/pull/10 |

The new flow will go from calling `task_worker()` to
<img width="1000" height="333" alt="CMIS Refactor Flow" src="https://github.com/user-attachments/assets/e9dfa22c-bc40-41d4-b4cb-9a39f02ff440" />

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
All unit tests continue to pass

#### Additional Information (Optional)
